### PR TITLE
Add vignette Rmds (created from Rnws)

### DIFF
--- a/vignettes/CO69.Rmd
+++ b/vignettes/CO69.Rmd
@@ -5,7 +5,7 @@ output:
   html_document:
     toc: true
 vignette: >
-  %\VignetteIndexEntry{Creating Neighbours using sf objects}
+  %\VignetteIndexEntry{The Problem of Spatial Autocorrelation:” forty years on}
   %\VignetteEngine{knitr::knitr}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/CO69.Rmd
+++ b/vignettes/CO69.Rmd
@@ -1,0 +1,709 @@
+---
+title: "“The Problem of Spatial Autocorrelation:” forty years on"
+author: "Roger Bivand"
+output:
+  html_document:
+    toc: true
+vignette: >
+  %\VignetteIndexEntry{Creating Neighbours using sf objects}
+  %\VignetteEngine{knitr::knitr}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+```
+
+## Introduction
+
+@cliff+ord:69, published forty years ago, marked a turning point in the
+treatment of spatial autocorrelation in quantitative geography. It
+provided the framework needed by any applied researcher to attempt an
+implementation for a different system, possibly using a different
+programming language. In this spirit, here we examine how spatial
+weights have been represented in implementations and may be reproduced,
+how the tabulated results in the paper may be reproduced, and how they
+may be extended to cover simulation.
+
+One of the major assertions of @cliff+ord:69 is that their statistic
+advances the measurement of spatial autocorrelation with respect to
+@moran:50 and @geary:54 because a more general specification of spatial
+weights could be used. This more general form has implications both for
+the preparation of the weights themselves, and for the calculation of
+the measures. We will look at spatial weights first, before moving on to
+consider the measures presented in the paper and some of their
+subsequent developments. Before doing this, we will put together a data
+set matching that used in @cliff+ord:69. They provide tabulated data for
+the counties of the Irish Republic, but omit Dublin from analyses. A
+shapefile included in this package, kindly made available by Michael
+Tiefelsdorf, is used as a starting point:
+
+```{r echo=TRUE,eval=TRUE,results='hide'}
+library(spdep)
+if (require(rgdal, quietly=TRUE)) {
+  eire <- readOGR(system.file("shapes/eire.shp", package="spData")[1])
+} else {
+  require(maptools, quietly=TRUE)
+  eire <- readShapeSpatial(system.file("shapes/eire.shp", package="spData")[1])
+}
+row.names(eire) <- as.character(eire$names)
+proj4string(eire) <- CRS("+proj=utm +zone=30 +ellps=airy +units=km")
+```
+```{r echo=TRUE,eval=TRUE}
+class(eire)
+names(eire)
+```
+
+and read into a SpatialPolygonsDataFrame — classes used for handling
+spatial data in are fully described in @bivandetal:08. To this we need
+to add the data tabulated in the paper in Table 2,[^1] p. 40, here in
+the form of a text file with added rainfall values from Table 9, p. 49:
+
+```{r echo=TRUE,eval=TRUE}
+fn <- system.file("etc/misc/geary_eire.txt", package="spdep")[1]
+ge <- read.table(fn, header=TRUE)
+names(ge)
+```
+
+Since we assigned the county names as feature identifiers when reading
+the shapefiles, we do the same with the extra data, and combine the
+objects:
+
+```{r echo=TRUE,eval=TRUE}
+row.names(ge) <- as.character(ge$county)
+all.equal(row.names(ge), row.names(eire))
+library(maptools)
+eire_ge <- spCbind(eire, ge)
+```
+
+Finally, we need to drop the Dublin county omitted in the analyses
+conducted in @cliff+ord:69:
+
+```{r echo=TRUE,eval=TRUE}
+eire_ge1 <- eire_ge[!(row.names(eire_ge) %in% "Dublin"),]
+length(row.names(eire_ge1))
+```
+
+To double-check our data, let us calculate the sample Beta coefficients,
+using the formulae given in the paper for sample moments:
+
+```{r echo=TRUE,eval=TRUE}
+skewness <- function(z) {z <- scale(z, scale=FALSE); ((sum(z^3)/length(z))^2)/((sum(z^2)/length(z))^3)}
+kurtosis <- function(z) {z <- scale(z, scale=FALSE); (sum(z^4)/length(z))/((sum(z^2)/length(z))^2)}
+```
+
+These differ somewhat from the ways in which skewness and kurtosis are
+computed in modern statistical software, see for example
+@joanes+gill:98. However, for our purposes, they let us reproduce Table
+3, p. 42:
+
+```{r echo=TRUE,eval=TRUE}
+print(sapply(as(eire_ge1, "data.frame")[13:24], skewness), digits=3)
+print(sapply(as(eire_ge1, "data.frame")[13:24], kurtosis), digits=4)
+print(sapply(as(eire_ge1, "data.frame")[c(13,16,18,19)], function(x) skewness(log(x))), digits=3)
+print(sapply(as(eire_ge1, "data.frame")[c(13,16,18,19)], function(x) kurtosis(log(x))), digits=4)
+```
+
+Using the tabulated value of $23.6$ for the percentage of agricultural
+holdings above 50 in 1950 in Waterford, the skewness and kurtosis cannot
+be reproduced, but by comparison with the [`irishdata`]{} dataset in ,
+it turns out that the value should rather be $26.6$, which yields the
+tabulated skewness and kurtosis values.
+
+Before going on, the variables considered are presented in Table
+\[vars\].
+
+  variable         description
+  ---------------- -----------------------------------------------------------------------------
+  pagval2\_10      Percentage number agricultural holdings in valuation group £2–£10 (1950)
+  pagval10\_50     Percentage number agricultural holdings in valuation group £10–£50 (1950)
+  pagval50p        Percentage number agricultural holdings in valuation group above £50 (1950)
+  cowspacre        Milch cows per 1000 acres crops and pasture (1952)
+  ocattlepacre     Other cattle per 1000 acres crops and pasture (1952)
+  pigspacre        Pigs per 1000 acres crops and pasture (1952)
+  sheeppacre       Sheep per 1000 acres crops and pasture (1952)
+  townvillp        Town and village population as percentage of total (1951)
+  carspcap         Private cars registered per 1000 population (1952)
+  radiopcap        Radio licences per 1000 population (1952)
+  retailpcap       Retail sales £ per person (1951)
+  psinglem30\_34   Single males as percentage of all males aged 30–34 (1951)
+  rainfall         Average of rainfall for stations in Ireland, 1916–1950, mm
+
+  : Description of variables in the Geary data set.[]{data-label="vars"}
+
+## Spatial weights
+
+As a basis for comparison, we will first read the unstandardised
+weighting matrix given in Table A1, p. 54, of the paper, reading a file
+corrected for the misprint giving O rather than D as a neighbour of V:
+
+```{r echo=TRUE,eval=TRUE}
+fn <- system.file("etc/misc/unstand_sn.txt", package="spdep")[1]
+unstand <- read.table(fn, header=TRUE)
+summary(unstand)
+```
+
+In the file, the counties are represented by their serial letters, so
+ordering and conversion to integer index representation is required to
+reach a representation similar to that of the SpatialStats module for
+spatial neighbours:
+
+```{r echo=TRUE,eval=TRUE}
+class(unstand) <- c("spatial.neighbour", class(unstand))
+of <- ordered(unstand$from)
+attr(unstand, "region.id") <- levels(of)
+unstand$from <- as.integer(of)
+unstand$to <- as.integer(ordered(unstand$to))
+attr(unstand, "n") <- length(unique(unstand$from))
+```
+
+Having done this, we can change its representation to a [`listw`]{}
+object, assigning an appropriate style (generalised binary) for
+unstandardised values:
+
+```{r echo=TRUE,eval=TRUE}
+lw_unstand <- sn2listw(unstand)
+lw_unstand$style <- "B"
+lw_unstand
+```
+
+Note that the values of S0, S1, and S2 correspond closely with those
+given on page 42 of the paper, $0.84688672$, $0.01869986$ and
+$0.12267319$. The discrepancies appear to be due to rounding in the
+printed table of weights.
+
+The contiguous neighbours represented in this object ought to match
+those found using [`poly2nb`]{}. However, we see that the reproduced
+contiguities have a smaller link count:
+
+```{r echo=TRUE,eval=TRUE}
+nb <- poly2nb(eire_ge1)
+nb
+```
+
+The missing link is between Clare and Kerry, perhaps by the
+Tarbert–Killimer ferry, but the counties are not contiguous, as Figure
+\[plot\_nb\] shows:
+
+```{r echo=TRUE,eval=TRUE}
+xx <- diffnb(nb, lw_unstand$neighbours, verbose=TRUE)
+```
+```{r echo=TRUE,eval=FALSE,results='hide'}
+plot(eire_ge1, border="grey60")
+plot(nb, coordinates(eire_ge1), add=TRUE, pch=".", lwd=2)
+plot(xx, coordinates(eire_ge1), add=TRUE, pch=".", lwd=2, col=3)
+```
+
+```{r eval=TRUE,echo=FALSE, fig.cap="County boundaries and contiguities"}
+par(mfrow=c(1,2))
+plot(eire_ge1, border="grey40")
+title(xlab="25 Irish counties")
+text(coordinates(eire_ge1), labels=as.character(eire_ge1$serlet), cex=0.8)
+plot(eire_ge1, border="grey60")
+title(xlab="Contiguities")
+plot(nb, coordinates(eire_ge1), add=TRUE, pch=".", lwd=2)
+plot(xx, coordinates(eire_ge1), add=TRUE, pch=".", lwd=2, col=3)
+legend("topleft", legend=c("Contiguous", "Ferry"), lwd=2, lty=1, col=c(1,3), bty="n", cex=0.7)
+par(mfrow=c(1,1))
+``` 
+
+An attempt has also been made to reproduce the generalised weights for
+25 Irish counties reported by @cliff+ord:69, after Dublin is omitted.
+Reproducing the inverse distance component $d_{ij}^{-1}$ of the
+generalised weights $d_{ij}^{-1} \beta_{i(j)}$ is eased by the statement
+in @cliff+ord:73 [p. 55] that the points chosen to represent the
+counties were their “geographic centres,” so not very different from the
+centroids yielded by applying a chosen computational geometry function.
+The distance metric is not given, and may have been in kilometers or
+miles — both were tried, but the results were not sensitive to the
+difference as it applies equally across the weights; miles are used
+here. Computing the proportion of shared distance measure $\beta_{i(j)}$
+is harder, because it requires the availability of the full topology of
+the input polygons. @bivandetal:08 [p. 244] show how to employ the
+[`vect2neigh`]{} function (written by Markus Neteler) in the package
+when using GRASS GIS vector handling to create a full topology from
+spaghetti vector data and to extract border segment lengths; a similar
+approach also is mentioned there using ArcGIS coverages for the same
+purpose. GRASS was used to create the topology, and next the proportion
+of shared distance measure was calculated.
+
+```{r echo=FALSE,eval=TRUE}
+load(system.file("etc/misc/raw_grass_borders.RData", package="spdep")[1])
+```
+```{r echo=TRUE,eval=FALSE,results='hide'}
+library(maptools)
+SG <- Sobj_SpatialGrid(eire_ge1)$SG
+library(spgrass6)
+grass_home <- "/home/rsb/topics/grass/g64/grass-6.4.0svn"
+initGRASS(grass_home, home=tempdir(), SG=SG, override=TRUE)
+writeVECT6(eire_ge1, "eire", v.in.ogr_flags=c("o", "overwrite"))
+res <- vect2neigh("eire", ID="serlet")
+```
+```{r echo=TRUE,eval=TRUE}
+grass_borders <- sn2listw(res)
+raw_borders <- grass_borders$weights
+int_tot <- attr(res, "total") - attr(res, "external")
+prop_borders <- lapply(1:length(int_tot), function(i) raw_borders[[i]]/int_tot[i])
+dlist <- nbdists(grass_borders$neighbours, coordinates(eire_ge1))
+inv_dlist <- lapply(dlist, function(x) 1/(x/1.609344))
+combo_km <- lapply(1:length(inv_dlist), function(i) inv_dlist[[i]]*prop_borders[[i]])
+combo_km_lw <- nb2listw(grass_borders$neighbours, glist=combo_km, style="B")
+summary(combo_km_lw)
+```
+
+To compare, we need to remove the Tarbert–Killimer ferry link manually,
+and view the summary of the original weights, as well as a correlation
+coefficient between these and the reconstructed weights. Naturally,
+unless the boundary coordinates used here are identical with those in
+the original analysis, presumably measured by hand, small differences
+will occur.
+
+```{r echo=TRUE,eval=TRUE}
+red_lw_unstand <- lw_unstand
+Clare <- which(attr(lw_unstand, "region.id") == "C")
+Kerry <- which(attr(lw_unstand, "region.id") == "H")
+Kerry_in_Clare <- which(lw_unstand$neighbours[[Clare]] == Kerry)
+Clare_in_Kerry <- which(lw_unstand$neighbours[[Kerry]] == Clare)
+red_lw_unstand$neighbours[[Clare]] <- red_lw_unstand$neighbours[[Clare]][-Kerry_in_Clare]
+red_lw_unstand$neighbours[[Kerry]] <- red_lw_unstand$neighbours[[Kerry]][-Clare_in_Kerry]
+red_lw_unstand$weights[[Clare]] <- red_lw_unstand$weights[[Clare]][-Kerry_in_Clare]
+red_lw_unstand$weights[[Kerry]] <- red_lw_unstand$weights[[Kerry]][-Clare_in_Kerry]
+summary(red_lw_unstand)
+cor(unlist(red_lw_unstand$weights), unlist(combo_km_lw$weights))
+```
+
+Even though the differences in the general weights, for identical
+contiguities, are so small, the consequences for the measure of spatial
+autocorrelation are substantial, Here we use the fifth variable, other
+cattle per 1000 acres crops and pasture (1952), and see that the
+reconstructed weights seem to “reveal” more autocorrelation than the
+original weights.
+
+```{r echo=TRUE,eval=TRUE}
+flatten <- function(x, digits=3, statistic="I") {
+  res <- c(format(x$estimate, digits=digits),
+    format(x$statistic, digits=digits),
+    format.pval(x$p.value, digits=digits))
+  res <- matrix(res, ncol=length(res))
+  colnames(res) <- paste(c("", "E", "V", "SD_", "P_"), "I", sep="")
+  rownames(res) <- deparse(substitute(x))
+  res
+}
+`reconstructed weights` <- moran.test(eire_ge1$ocattlepacre, combo_km_lw)
+`original weights` <- moran.test(eire_ge1$ocattlepacre, red_lw_unstand)
+print(rbind(flatten(`reconstructed weights`), flatten(`original weights`)), quote=FALSE)
+```
+
+## Measures of spatial autocorrelation
+
+Our targets for reproduction are Tables 4 and 5 in @cliff+ord:69 [pp.
+43–44], the first containing standard deviates under normality and
+randomisation for the original Moran measure with binary weights, the
+original Geary measure with binary weights, the proposed measure with
+unstandardised general weights, and the proposed measure with
+row-standardised general weights. In addition, four variables were
+log-transformed on the basis of the skewness and kurtosis results
+presented above. We carry out the transformation of these variables, and
+generate additional binary and row-standardised general spatial weights
+objects — note that the weights constants for the row-standardised
+general weights agree with those given on p. 42 in the paper, after
+allowing for small differences due to rounding in the weights values
+displayed in the paper (p. 54):
+
+```{r echo=TRUE,eval=TRUE}
+eire_ge1$ln_pagval2_10 <- log(eire_ge1$pagval2_10)
+eire_ge1$ln_cowspacre <- log(eire_ge1$cowspacre)
+eire_ge1$ln_pigspacre <- log(eire_ge1$pigspacre)
+eire_ge1$ln_sheeppacre <- log(eire_ge1$sheeppacre)
+vars <- c("pagval2_10", "ln_pagval2_10", "pagval10_50", "pagval50p",
+ "cowspacre", "ln_cowspacre", "ocattlepacre", "pigspacre",
+ "ln_pigspacre", "sheeppacre", "ln_sheeppacre", "townvillp",
+ "carspcap", "radiopcap", "retailpcap", "psinglem30_34")
+nb_B <- nb2listw(lw_unstand$neighbours, style="B")
+nb_B
+lw_std <- nb2listw(lw_unstand$neighbours, glist=lw_unstand$weights, style="W")
+lw_std
+```
+
+The standard representation of the measures is:
+
+$$I = \frac{n}{\sum_{i=1}^{n}\sum_{j=1}^{n}w_{ij}}
+\frac{\sum_{i=1}^{n}\sum_{j=1}^{n}w_{ij}(x_i-\bar{x})(x_j-\bar{x})}{\sum_{i=1}^{n}(x_i - \bar{x})^2}$$
+
+for Moran’s $I$ — in the paper termed the proposed statistic, and for
+Geary’s $C$:
+
+$$C = \frac{(n-1)}{2\sum_{i=1}^{n}\sum_{j=1}^{n}w_{ij}}
+\frac{\sum_{i=1}^{n}\sum_{j=1}^{n}w_{ij}(x_i-x_j)^2}{\sum_{i=1}^{n}(x_i - \bar{x})^2}$$
+
+where $x_i, i=1, \ldots, n$ are $n$ observations on the numeric variable
+of interest, and $w_{ij}$ are the spatial weights. In order to reproduce
+the standard deviates given in the paper, it is sufficient to apply
+[`moran.test`]{} to the variables with three different spatial weights
+objects, and two different values of the [`randomisation=`]{} argument.
+In addition, [`geary.test`]{} is applied to a single spatial weights
+objects, and two different values of the [`randomisation=`]{} argument.
+
+```{r echo=TRUE,eval=TRUE}
+system.time({
+MoranN <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=nb_B, randomisation=FALSE))
+MoranR <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=nb_B, randomisation=TRUE))
+GearyN <- lapply(vars, function(x) geary.test(eire_ge1[[x]], listw=nb_B, randomisation=FALSE))
+GearyR <- lapply(vars, function(x) geary.test(eire_ge1[[x]], listw=nb_B, randomisation=TRUE))
+Prop_unstdN  <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=lw_unstand, randomisation=FALSE))
+Prop_unstdR  <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=lw_unstand, randomisation=TRUE))
+Prop_stdN  <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=lw_std, randomisation=FALSE))
+Prop_stdR  <- lapply(vars, function(x) moran.test(eire_ge1[[x]], listw=lw_std, randomisation=TRUE))
+})
+res <- sapply(c("MoranN", "MoranR", "GearyN", "GearyR", "Prop_unstdN", "Prop_unstdR", "Prop_stdN", "Prop_stdR"), function(x) sapply(get(x), "[[", "statistic"))
+rownames(res) <- vars
+ores <- res[,c(1,2,5:8)]
+```
+
+In order to conduct 8 different tests on 16 variables, we use
+[`lapply`]{} on the list of variables in the specified order, then
+[`sapply`]{} on a list of output objects by name to generate a table in
+the same row and column order as the original (we save a copy of six
+columns for comparison with bootstrap results below):
+
+```{r echo=FALSE,eval=TRUE}
+options("width"=100)
+```
+```{r echo=TRUE,eval=TRUE}
+print(formatC(res, format="f", digits=4), quote=FALSE)
+```
+```{r echo=FALSE,eval=TRUE}
+options("width"=90)
+```
+
+The values of the standard deviates agree with those in Table 4 in the
+original paper, with the exception of those for the proposed statistic
+with standardised weights under normality for all untransformed
+variables. We can see what has happened by substituting the weights
+constants for the standardised weights with those for unstandardised
+weights:
+
+```{r echo=TRUE,eval=TRUE}
+wc_unstd <- spweights.constants(lw_unstand)
+wrong_N_sqVI <- sqrt((wc_unstd$nn*wc_unstd$S1 - wc_unstd$n*wc_unstd$S2 + 3*wc_unstd$S0*wc_unstd$S0)/((wc_unstd$nn-1)*wc_unstd$S0*wc_unstd$S0)-((-1/(wc_unstd$n-1))^2))
+raw_data <- grep("^ln_", vars, invert=TRUE)
+I <- sapply(Prop_stdN, function(x) x$estimate[1])[raw_data]
+EI <- sapply(Prop_stdN, function(x) x$estimate[2])[raw_data]
+res <- (I - EI)/wrong_N_sqVI
+names(res) <- vars[raw_data]
+print(formatC(res, format="f", digits=4), quote=FALSE)
+```
+
+Next, let us look at Table 5 in the original paper. Here we only
+tabulate the values of the measures themselves, and, since the
+expectation is constant for each measure, the square root of the
+variance of the measure under randomisation — extracting values
+calculated above:
+
+```{r echo=TRUE,eval=TRUE}
+res <- lapply(c("MoranR", "GearyR", "Prop_unstdR", "Prop_stdR"), function(x) sapply(get(x), function(y) c(y$estimate[1], sqrt(y$estimate[3]))))
+res <- t(do.call("rbind", res))
+colnames(res) <- c("I", "sigma_I", "C", "sigma_C", "unstd_r", "sigma_r", "std_r", "sigma_r")
+rownames(res) <- vars
+print(formatC(res, format="f", digits=4), quote=FALSE)
+```
+
+The values are as follows, and match the original with the exception of
+those for the initial version of Moran’s $I$ in the first two columns.
+If we write a function implementing equations 3 and 4:
+
+$$I = \frac{\sum_{i=1}^{n}\sum_{j=i+1}^{n}w_{ij}(x_i-\bar{x})(x_j-\bar{x})}{\sum_{i=1}^{n}(x_i - \bar{x})^2}$$
+
+where crucially the inner summation is over $i+1 \ldots n$, not
+$1 \ldots
+n$, we can reproduce the values of the measure shown in the original
+Table 5:
+
+```{r echo=TRUE,eval=TRUE}
+oMoranf <- function(x, nb) {
+  z <- scale(x, scale=FALSE)
+  n <- length(z)
+  glist <- lapply(1:n, function(i) {ii <- nb[[i]]; ifelse(ii > i, 1, 0)})
+  lw <- nb2listw(nb, glist=glist, style="B")
+  wz <- lag(lw, z)
+  I <- (sum(z*wz)/sum(z*z))
+  I
+}
+res <- sapply(vars, function(x) oMoranf(eire_ge1[[x]], nb=lw_unstand$neighbours))
+print(formatC(res, format="f", digits=4), quote=FALSE)
+```
+
+The variance term given in equation 7 in the original paper is for the
+case of normality, not randomisation; the reference on p. 28 to equation
+38 on p. 26 does not permit the reproduction of the values in the second
+column of Table 5. The variance equation given as equation 1.35 by
+@cliff+ord:73 [p. 9] does not do so either, so for the time being it is
+not possible to say how the tabulated values were computed. Note that
+since the standard deviances are reproduced correctly, and can be
+reproduced from the second column values using the measure and its
+expectance, it is just a matter of establishing which formula was used,
+but this has so far not proved possible.
+
+## Simulating measures of spatial autocorrelation
+
+@cliff+ord:69 do not conduct simulation experiments, although their
+sequels do, notably @cliff+ord:73, among many others. Simulation studies
+are necessarily more demanding computationally, especially if spatially
+autocorrelated variables are to be created, as in @cliff+ord:73 [pp.
+146–153]. In the same book, they also report the use of permutation
+tests, also known as Monte Carlo or Hope hypothesis testing procedures
+[@cliff+ord:73 pp. 50–52]. These procedures provided a way to examine
+the distribution of the statistic of interest by exchanging at random
+the observed values between observations, and then comparing the
+simulated distribution under the null hypothesis of no spatial
+patterning with the observed value of the statistic in question.
+
+```{r echo=TRUE,eval=TRUE}
+MoranI.boot <- function(var, i, ...) {
+  var <- var[i]
+  return(moran(x=var, ...)$I)
+}
+Nsim <- function(d, mle) {
+  n <- length(d)
+  rnorm(n, mle$mean, mle$sd)
+}
+f_bperm <- function(x, nsim, listw) {
+  boot(x, statistic=MoranI.boot, R=nsim, sim="permutation", listw=listw,
+    n=length(x), S0=Szero(listw))
+}
+f_bpara <- function(x, nsim, listw) {
+  boot(x, statistic=MoranI.boot, R=nsim, sim="parametric", ran.gen=Nsim,
+    mle=list(mean=mean(x), sd=sd(x)), listw=listw, n=length(x),
+    S0=Szero(listw))
+}
+nsim <- 4999
+set.seed(1234)
+```
+
+First let us define a function [`MoranI.boot`]{} just to return the
+value of Moran’s $I$ for variable [`var`]{} and permutation index
+[`i`]{}, and a function [`Nsim`]{} to generate random samples from the
+variable of interest assuming Normality. To make it easier to process
+the variables in turn, we encapsulate calls to [`boot`]{} in wrapper
+functions [`f_bperm`]{} and [`f_bpara`]{}. Running 4999 simulations for
+each of 16 for three different weights specifications and both
+parametric and permutation bootstrap takes quite a lot of time.
+
+```{r echo=TRUE,eval=FALSE}
+system.time({
+MoranNb <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=nb_B))
+MoranRb <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=nb_B))
+Prop_unstdNb  <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=lw_unstand))
+Prop_unstdRb  <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=lw_unstand))
+Prop_stdNb  <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=lw_std))
+Prop_stdRb  <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=lw_std))
+})
+```
+```{r echo=FALSE,eval=FALSE}
+zzz <- system.time({
+MoranNb <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=nb_B))
+MoranRb <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=nb_B))
+Prop_unstdNb  <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=lw_unstand))
+Prop_unstdRb  <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=lw_unstand))
+Prop_stdNb  <- lapply(vars, function(x) f_bpara(x=eire_ge1[[x]], nsim=nsim, listw=lw_std))
+Prop_stdRb  <- lapply(vars, function(x) f_bperm(x=eire_ge1[[x]], nsim=nsim, listw=lw_std))
+})
+res <- lapply(c("MoranNb", "MoranRb", "Prop_unstdNb", "Prop_unstdRb", "Prop_stdNb", "Prop_stdRb"), function(x) sapply(get(x), function(y) (y$t0 - mean(y$t))/sd(y$t)))
+res <- t(do.call("rbind", res))
+colnames(res) <- c("MoranNb", "MoranRb", "Prop_unstdNb", "Prop_unstdRb", "Prop_stdNb", "Prop_stdRb")
+rownames(res) <- vars
+save(zzz, res, file="backstore/boot_res.RData")
+```
+```{r echo=FALSE,eval=FALSE}
+bsfn <- system.file("etc/backstore/boot_res.RData", package="spdep")
+load(bsfn)
+zzz
+```
+```{r echo=TRUE,eval=FALSE}
+res <- lapply(c("MoranNb", "MoranRb", "Prop_unstdNb", "Prop_unstdRb", "Prop_stdNb", "Prop_stdRb"), function(x) sapply(get(x), function(y) (y$t0 - mean(y$t))/sd(y$t)))
+res <- t(do.call("rbind", res))
+colnames(res) <- c("MoranNb", "MoranRb", "Prop_unstdNb", "Prop_unstdRb", "Prop_stdNb", "Prop_stdRb")
+rownames(res) <- vars
+```
+
+We collate the results to compare with the analytical standard deviates
+under Normality and randomisation, and see that in fact the differences
+are not at all large, as expressed by the median absolute difference
+between the tables. We can also see that inferences based on a one-sided
+$\alpha=0.05$ cut-off are the same for the analytical and bootstrap
+approaches. This indicates that we can, in general, rely on the
+analytical standard deviates, and that bootstrap methods will not help
+if assumptions underlying the measures are not met.
+
+```{r echo=TRUE,eval=TRUE}
+print(formatC(res, format="f", digits=4), quote=FALSE)
+oores <- ores - res
+apply(oores, 2, mad)
+alpha_0.05 <- qnorm(0.05, lower.tail=FALSE)
+all((res >= alpha_0.05) == (ores >= alpha_0.05))
+```
+
+These assumptions affect the shape of the distribution of the measure in
+its tails; one possibility is to use a Saddlepoint approximation to find
+an equivalent to the analytical or bootstrap-based standard deviate for
+inference [@tiefelsdorf:02]. The Saddlepoint approximation requires the
+eigenvalues of the weights matrix and iterative root-finding for global
+Moran’s $I$, while for local Moran’s $I_i$, analytical forms are known.
+Even with this computational burden, the Saddlepoint approximation for
+global Moran’s $I$ runs quite quickly. First we need to fit null linear
+models (only including an intercept) to the variables, then apply
+[`lm.morantest.sad`]{} to the fitted model objects:
+
+```{r echo=TRUE,eval=TRUE}
+lm_objs <- lapply(vars, function(x) lm(formula(paste(x, "~1")), data=eire_ge1))
+system.time({
+MoranSad <- lapply(lm_objs, function(x) lm.morantest.sad(x, listw=nb_B))
+Prop_unstdSad  <- lapply(lm_objs, function(x) lm.morantest.sad(x, listw=lw_unstand))
+Prop_stdSad  <- lapply(lm_objs, function(x) lm.morantest.sad(x, listw=lw_std))
+})
+res <- sapply(c("MoranSad", "Prop_unstdSad", "Prop_stdSad"), function(x) sapply(get(x), "[[", "statistic"))
+rownames(res) <- vars
+```
+
+Although the analytical standard deviates (under Normality) are larger
+than those reached using the Saddlepoint approximation when measured by
+median absolute deviation, the differences do not lead to different
+inferences at this chosen cut-off. This reflects the fact that the shape
+of the distribution is very sensitive to small $n$, but for moderate $n$
+and global Moran’s $I$, the effects are seen only further out in the
+tails. The consequences for local Moran’s $I_i$ are much stronger,
+because the clique of neighbours of each observation is typically very
+small. It is perhaps of interest that the differences are much smaller
+for the case of general weights than for unstandardised binary weights.
+
+```{r echo=TRUE,eval=TRUE}
+print(formatC(res, format="f", digits=4), quote=FALSE)
+oores <- res - ores[,c(1,3,5)]
+apply(oores, 2, mad)
+all((res >= alpha_0.05) == (ores[,c(1,3,5)] >= alpha_0.05))
+```
+
+In addition we could choose to use the exact distribution of Moran’s
+$I$, as described by @tiefelsdorf:00; its implementation is covered in
+@bivandetal:09. The global case also needs the eigenvalues of the
+weights matrix, and the solution of a numerical integration function,
+but for these cases, the timings are quite acceptable.
+
+```{r echo=TRUE,eval=TRUE}
+system.time({ 
+MoranEx <- lapply(lm_objs, function(x) lm.morantest.exact(x, listw=nb_B))
+Prop_unstdEx  <- lapply(lm_objs, function(x) lm.morantest.exact(x, listw=lw_unstand))
+Prop_stdEx  <- lapply(lm_objs, function(x) lm.morantest.exact(x, listw=lw_std))
+})
+res <- sapply(c("MoranEx", "Prop_unstdEx", "Prop_stdEx"), function(x) sapply(get(x), "[[", "statistic"))
+rownames(res) <- vars
+```
+
+The output is comparable with that of the Saddlepoint approximation, and
+the inferences drawn here are the same for the chosen cut-off as for the
+analytical standard deviates calculated under Normality.
+
+```{r echo=TRUE,eval=TRUE}
+print(formatC(res, format="f", digits=4), quote=FALSE)
+oores <- res - ores[,c(1,3,5)]
+apply(oores, 2, mad)
+all((res >= alpha_0.05) == (ores[,c(1,3,5)] >= alpha_0.05))
+```
+
+@lietal:07 take up the challenge in @cliff+ord:69 [p. 31], to try to
+give the statistic a bounded fixed range. Their APLE measure is intended
+to approximate the spatial dependence parameter of a simultaneous
+autoregressive model better than Moran’s $I$, and re-scales the measure
+by a function of the eigenvalues of the spatial weights matrix. APLE
+requires the use of row standardised weights.
+
+```{r echo=TRUE,eval=TRUE}
+vars_scaled <- lapply(vars, function(x) scale(eire_ge1[[x]], scale=FALSE))
+nb_W <- nb2listw(lw_unstand$neighbours, style="W")
+pre <- spdep:::preAple(0, listw=nb_W)
+MoranAPLE <- sapply(vars_scaled, function(x) spdep:::inAple(x, pre))
+pre <- spdep:::preAple(0, listw=lw_std, override_similarity_check=TRUE)
+Prop_stdAPLE <- sapply(vars_scaled, function(x) spdep:::inAple(x, pre))
+res <- cbind(MoranAPLE, Prop_stdAPLE)
+colnames(res) <- c("APLE W", "APLE Gstd")
+rownames(res) <- vars
+```
+
+In order to save time, we use the two internal functions
+[`spdep:::preAple`]{} and [`spdep:::inAple`]{}, since for each
+definition of spatial weights, the same eigenvalue calculations need to
+be made. The notation using the [`:::`]{} operator says that the
+function with named after the operator is to be found in the namespace
+of the package named before the operator. The APLE values repeat the
+pattern that we have already seen — for some variables, the measured
+autocorrelation is very similar irrespective of spatial weights
+definition, while for others, the change in the definition from binary
+to general does make a difference.
+
+```{r echo=TRUE,eval=TRUE}
+print(formatC(res, format="f", digits=4), quote=FALSE)
+```
+
+```{r results='asis',eval=TRUE,echo=FALSE, fig.cap="Three contrasted spatial weights definitions"}
+pal <- grey.colors(9, 1, 0.5, 2.2)
+oopar <- par(mfrow=c(1,3), mar=c(1,1,3,1)+0.1)
+z <- t(listw2mat(nb_B))
+brks <- c(0,0.1,1)
+image(1:25, 1:25, z[,ncol(z):1], breaks=brks, col=pal[c(1,9)],
+ main="Binary", axes=FALSE)
+box()
+z <- t(listw2mat(lw_unstand))
+brks <- c(0,quantile(c(z)[c(z) > 0], seq(0,1,1/8)))
+image(1:25, 1:25, z[,ncol(z):1], breaks=brks, col=pal, main="General", axes=FALSE)
+box()
+z <- t(listw2mat(lw_std))
+brks <- c(0,quantile(c(z)[c(z) > 0], seq(0,1,1/8)))
+image(1:25, 1:25, z[,ncol(z):1], breaks=brks, col=pal,
+ main="Std. general", axes=FALSE)
+box()
+par(oopar)
+``` 
+\caption{Three contrasted spatial weights definitions.}
+\label{plot_wts}
+
+```{r results='asis',eval=TRUE,echo=FALSE}
+eire_ge1$nb_B <- sapply(nb_B$weights, sum)
+eire_ge1$lw_unstand <- sapply(lw_unstand$weights, sum)
+library(lattice)
+trellis.par.set(sp.theme())
+p1 <- spplot(eire_ge1, c("nb_B"), main="Binary")
+p2 <- spplot(eire_ge1, c("lw_unstand"), main="General")
+print(p1, split=c(1,1,2,1), more=TRUE)
+print(p2, split=c(2,1,2,1), more=FALSE)
+``` 
+\caption{Sums of weights by county for two contrasted spatial weights definitions --- for row standardisation, all counties sum to unity.}
+\label{plot_map}
+
+## Odds and ends $\ldots$
+
+The differences found in the case of a few variables in inference using
+the original binary weights, and the general weights proposed by
+@cliff+ord:69 are necessarily related to the the weights thenselves.
+Figures \[plot\_wts\] and \[plot\_map\] show the values of the weights
+in sparse matrix form, and the sums of weights by county where these
+sums are not identical by design. In the case of binary weights, the
+matrix entries are equal, but the sums up-weight counties with many
+neighbours.
+
+General weights up-weight counties that are close to each other, have
+more neighbours, and share larger boundary proportions (an asymmetric
+relationship). There is a further impact of using boundary proportions,
+in that the boundary between the county and the exterior is subtracted,
+thus boosting the weights between edge counties and their neighbours,
+even if there are few of them. Standardised general weights up-weight
+further up-weight counties with few neighbours, chiefly those on the
+edges of the study area.
+
+With a small data set, here with $n=25$, it is very possible that edge
+and other configuration effects are relatively strong, and may impact
+inference in different ways. The issue of egde effects has not really
+been satisfactorily resolved, and should be kept in mind in analyses of
+data sets of this size and shape.
+
+[^1]: cropped scans of tables are available from
+    <http://spatial.nhh.no/R/etc/CO69-PNGs.zip>.

--- a/vignettes/CO69.Rmd
+++ b/vignettes/CO69.Rmd
@@ -4,6 +4,7 @@ author: "Roger Bivand"
 output:
   html_document:
     toc: true
+bibliography: refs.bib
 vignette: >
   %\VignetteIndexEntry{The Problem of Spatial Autocorrelation:” forty years on}
   %\VignetteEngine{knitr::knitr}
@@ -704,6 +705,8 @@ and other configuration effects are relatively strong, and may impact
 inference in different ways. The issue of egde effects has not really
 been satisfactorily resolved, and should be kept in mind in analyses of
 data sets of this size and shape.
+
+## References
 
 [^1]: cropped scans of tables are available from
     <http://spatial.nhh.no/R/etc/CO69-PNGs.zip>.

--- a/vignettes/SpatialFiltering.Rmd
+++ b/vignettes/SpatialFiltering.Rmd
@@ -1,0 +1,145 @@
+---
+title: "Moran Eigenvectors"
+author: "Roger Bivand"
+output:
+  html_document:
+    toc: true
+vignette: >
+  %\VignetteIndexEntry{Moran Eigenvectors}
+  %\VignetteEngine{knitr::knitr}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+```
+
+## Introduction
+
+The Moran eigenvector approach
+[@dray+legendre+peres-neto:06; @griffith+peres-neto:06] involved the
+spatial patterns represented by maps of eigenvectors; by choosing
+suitable orthogonal patterns and adding them to a linear or generalised
+linear model, the spatial dependence present in the residuals can be
+moved into the model.
+
+It uses brute force to search the set of eigenvectors of the matrix
+$\mathbf{M W M}$, where
+
+$$\mathbf{M} = \mathbf{I} - \mathbf{X}(\mathbf{X}^{\rm T}
+\mathbf{X})^{-1}\mathbf{X}^{\rm T}$$ is a symmetric and idempotent
+projection matrix and $\mathbf{W}$ are the spatial weights. In the
+spatial lag form of [`SpatialFiltering`]{} and in the GLM [`ME`]{} form
+below, $\mathbf{X}$ is an $n$-vector of ones, that is the intercept
+only.
+
+In its general form, [`SpatialFiltering`]{} chooses the subset of the
+$n$ eigenvectors that reduce the residual spatial autocorrelation in the
+error of the model with covariates. The lag form adds the covariates in
+assessment of which eigenvectors to choose, but does not use them in
+constructing the eigenvectors. [`SpatialFiltering`]{} was implemented
+and contributed by Yongwan Chun and Michael Tiefelsdorf, and is
+presented in @tiefelsdorf+griffith:07; [`ME`]{} is based on Matlab code
+by Pedro Peres-Neto and is discussed in @dray+legendre+peres-neto:06 and
+@griffith+peres-neto:06.
+
+```{r echo=TRUE}
+library(spdep)
+if (require(rgdal, quietly=TRUE)) {
+  NY8 <- readOGR(system.file("shapes/NY8_utm18.shp", package="spData"))
+} else {
+  require(maptools, quietly=TRUE)
+  NY8 <- readShapeSpatial(system.file("shapes/NY8_utm18.shp", package="spData"))
+}
+NY_nb <- read.gal(system.file("weights/NY_nb.gal", package="spData"), region.id=row.names(NY8))
+```
+
+```{r echo=TRUE,eval=TRUE}
+nySFE <- SpatialFiltering(Z~PEXPOSURE+PCTAGE65P+PCTOWNHOME, data=NY8, nb=NY_nb, style="W", verbose=FALSE)
+nylmSFE <- lm(Z~PEXPOSURE+PCTAGE65P+PCTOWNHOME+fitted(nySFE), data=NY8)
+summary(nylmSFE)
+nylm <- lm(Z~PEXPOSURE+PCTAGE65P+PCTOWNHOME, data=NY8)
+anova(nylm, nylmSFE)
+```
+
+Since the [`SpatialFiltering`]{} approach does not allow weights to be
+used, we see that the residual autocorrelation of the original linear
+model is absorbed, or ‘whitened’ by the inclusion of selected
+eigenvectors in the model, but that the covariate coefficients change
+little. The addition of these eigenvectors – each representing an
+independent spatial pattern – relieves the residual autocorrelation, but
+otherwise makes few changes in the substantive coefficient values.
+
+The [`ME`]{} function also searches for eigenvectors from the spatial
+lag variant of the underlying model, but in a GLM framework. The
+criterion is a permutation bootstrap test on Moran’s $I$ for regression
+residuals, and in this case, because of the very limited remaining
+spatial autocorrelation, is set at $\alpha = 0.5$. Even with this very
+generous stopping rule, only few eigenvectors are chosen; their combined
+contribution only just improves the fit of the GLM model.
+
+```{r echo=TRUE}
+NYlistwW <- nb2listw(NY_nb, style = "W")
+set.seed(111)
+```
+
+```{r echo=TRUE,eval=FALSE}
+nyME <- ME(Cases~PEXPOSURE+PCTAGE65P+PCTOWNHOME, data=NY8, offset=log(POP8), family="poisson", listw=NYlistwW, alpha=0.5)
+```
+
+```{r echo=FALSE, eval=FALSE}
+bsfn <- system.file("etc/backstore/nyME_res.RData", package="spdep")
+load(bsfn)
+```
+
+```{r echo=TRUE, eval=FALSE}
+nyME
+NY8$eigen_24 <- fitted(nyME)[,1]
+NY8$eigen_223 <- fitted(nyME)[,2]
+```
+
+```{r results='asis',echo=FALSE, eval=FALSE}
+.iwidth <- 6
+.iheight <- 4
+.ipointsize <- 10
+library(RColorBrewer)
+#gry <- brewer.pal(9, "Greys")[-1]
+spplot(NY8, c("eigen_24", "eigen_223"), col.regions=grey.colors(6, 0.95, 0.55, 2.2), cuts=5)
+``` 
+
+```{r echo=TRUE,eval=FALSE}
+nyglmME <- glm(Cases~PEXPOSURE+PCTAGE65P+PCTOWNHOME+offset(log(POP8))+fitted(nyME), data=NY8, family="poisson")
+summary(nyglmME)
+nyGLMp <- glm(Cases~PEXPOSURE+PCTAGE65P+PCTOWNHOME+offset(log(POP8)), data=NY8,family="poisson")
+anova(nyGLMp, nyglmME, test="Chisq")
+```
+
+Figure \[fig:geigen2\] shows the spatial patterns chosen to match the
+very small amount of spatial autocorrelation remaining in the model. As
+with the other Poisson regressions, the closeness to TCE sites is highly
+significant. Since, however, many TCE sites are also in or close to more
+densely populated urban areas with the possible presence of both
+point-source and non-point-source pollution, it would be premature to
+take such results simply at their face value. There is, however, a
+potentially useful contrast between the cities of Binghampton in the
+south of the study area with several sites in its vicinity, and Syracuse
+in the north without TCE sites in this data set.
+
+Dray, S., Legendre, P., and Peres-Neto, P. R. (2006). Spatial modeling:
+A comprehensive framework for principle coordinate analysis of neighbor
+matrices ([PCNM]{}). [*Ecological Modelling*]{}, 196:483–493.
+
+Griffith, D. A. and Peres-Neto, P. R. (2006). Spatial modeling in
+ecology: The flexibility of eigenfunction spatial analyses.
+[*Ecology*]{}, 87:2603–2613.
+
+Tiefelsdorf, M. and Griffith, D. A. (2007). Semiparametric filtering of
+spatial autocorrelation: The eigenvector approach. [*Environment and
+Planning A*]{}, 39:1193–1221.
+
+[^1]: This vignette formed pp. 302–305 of the first edition of Bivand,
+    R. S., Pebesma, E. and Gómez-Rubio V. (2008) Applied Spatial Data
+    Analysis with R, Springer-Verlag, New York. It was retired from the
+    second edition (2013) to accommodate material on other topics, and
+    is made available in this form with the understanding of the
+    publishers.

--- a/vignettes/SpatialFiltering.Rmd
+++ b/vignettes/SpatialFiltering.Rmd
@@ -2,8 +2,8 @@
 title: "Moran Eigenvectors"
 author: "Roger Bivand"
 output:
-  html_document:
-    toc: true
+  html_document
+bibliography: refs.bib
 vignette: >
   %\VignetteIndexEntry{Moran Eigenvectors}
   %\VignetteEngine{knitr::knitr}
@@ -125,17 +125,7 @@ potentially useful contrast between the cities of Binghampton in the
 south of the study area with several sites in its vicinity, and Syracuse
 in the north without TCE sites in this data set.
 
-Dray, S., Legendre, P., and Peres-Neto, P. R. (2006). Spatial modeling:
-A comprehensive framework for principle coordinate analysis of neighbor
-matrices ([PCNM]{}). [*Ecological Modelling*]{}, 196:483–493.
-
-Griffith, D. A. and Peres-Neto, P. R. (2006). Spatial modeling in
-ecology: The flexibility of eigenfunction spatial analyses.
-[*Ecology*]{}, 87:2603–2613.
-
-Tiefelsdorf, M. and Griffith, D. A. (2007). Semiparametric filtering of
-spatial autocorrelation: The eigenvector approach. [*Environment and
-Planning A*]{}, 39:1193–1221.
+## References
 
 [^1]: This vignette formed pp. 302–305 of the first edition of Bivand,
     R. S., Pebesma, E. and Gómez-Rubio V. (2008) Applied Spatial Data

--- a/vignettes/refs.bib
+++ b/vignettes/refs.bib
@@ -1,0 +1,257 @@
+@book{bailey+gatrell:1995,
+author = {Bailey, T. C. and Gatrell, A. C.},
+title = {Interactive Spatial Data Analysis},
+year = {1995},
+publisher = {Longman},
+address = {Harlow}
+}
+
+@article{choynowski:1959,
+author = {Choynowski, M.},
+title = {Maps based on probabilities},
+year = {1959},
+journal = {Journal of the American Statistical Association},
+volume = {54},
+pages = {385--388}
+}
+
+@book{cressie:1991,
+author = {Cressie, N.},
+title = {Statistics for spatial data},
+year = {1991},
+publisher = {Wiley},
+address = {New York}
+}
+
+@article{cressie+chan:1989,
+author = {Cressie, N. and Chan N. H.},
+title = {Spatial modelling of regional variables},
+year = {1989},
+journal = {Journal of the American Statistical Association},
+volume = {84},
+pages = {393--401}
+}
+@article{cressie+read:1985,
+author = {Cressie, N. and Read, T. R. C.},
+title = {Do sudden infant deaths come in clusters?},
+year = {1985},
+journal = {Statistics and Decisions},
+volume = {Supplement Issue 2},
+pages = {333--349}
+}
+
+@article{cressie+read:1989,
+author = {Cressie, N. and Read, T. R. C.},
+title = {Spatial data-analysis of regional counts},
+year = {1989},
+journal = {Biometrical Journal},
+volume = {31},
+pages = {699--719}
+}
+
+@book{kaluznyetal:1996,
+author = {Kaluzny, S. P. and Vega, S. C. and Cardoso, T. P. and Shelly, A. A.},
+title = {{S-PLUS SPATIALSTATS} user's manual version 1.0},
+year = {1996},
+publisher = {MathSoft Inc.},
+address = {Seattle}
+}
+
+@article{marshall:1991,
+author = {Marshall, R. M.},
+title = {Mapping disease and mortality rates using Empirical {Bayes} Estimators},
+year = {1991},
+journal = {Applied Statistics},
+volume = {40},
+pages = {283--294}
+}
+
+@article{symonsetal:1983,
+author = {Symons, M. J. and Grimson, R. C. and Yuan, Y. C.},
+title = {Clustering of rare events},
+year = {1983},
+journal = {Biometrics},
+volume = {39},
+pages = {193--205}
+}
+
+@article{gomez-rubio+ferrandiz+lopez:2003,
+   author    = {V. G\'omez-Rubio and J. Ferr\'andiz-Ferragud and A. L\'opez-Qu\'ilez},
+   title     = {Detecting Clusters of Disease with {R}},
+   journal   = {Journal of Geographical Systems},
+   pages     = {189-206},
+   year      = {2005},
+   volume    = {7}
+}
+
+@book{WallerGotway:2004,
+author = {Waller, L. A. and Gotway, C. A.},
+title = {Applied Spatial Statistics for Public Health Data},
+year = {2004},
+publisher = {John Wiley \& Sons},
+address = {Hoboken, NJ}
+}
+
+@article{matula+sokal:80,
+   author    = {Matula, D. W. and Sokal, R. R.},
+   title     = {Properties of {G}abriel graphs relevant to geographic variation research and the clustering of points in the plane},
+   journal   = {Geographical Analysis},
+   pages     = {205--222},
+   year      = {1980},
+   volume    = {12}
+}
+
+@article{toussaint:80,
+   author    = {Toussaint, G. T.},
+   title     = {The relative neighborhood graph of a finite planar set},
+   journal   = {Pattern Recognition},
+   pages     = {261--268},
+   year      = {1980},
+   volume    = {12}
+}
+
+@book{osullivan+unwin:03,
+author = {O'Sullivan, D. and Unwin, D. J.},
+title = {Geographical Information Analysis},
+year = {2003},
+publisher = {Wiley},
+address = {Hoboken, NJ}
+}
+
+@incollection{avis+horton:1985,
+author = {Avis, D. and Horton, J.},
+title = {Remarks on the sphere of influence graph},
+booktitle = {Discrete Geometry and Convexity},
+editor = {Goodman, J. E.},
+   pages     = {323--327},
+year = {1985},
+publisher = {New York Academy of Sciences, New York},
+address = {New York}
+}
+
+@article{dray+legendre+peres-neto:06,
+   author    = {Dray, S. and Legendre, P. and Peres-Neto, P. R.},
+   title     = {Spatial modeling: A comprehensive framework for principle coordinate analysis of neighbor matrices ({PCNM})},
+   journal   = {Ecological Modelling},
+   pages     = {483--493},
+   year      = {2006},
+   volume    = {196}
+}
+
+@article{griffith+peres-neto:06,
+   author    = {Griffith, D. A. and Peres-Neto, P. R.},
+   title     = {Spatial modeling in ecology: The flexibility of eigenfunction spatial
+  analyses},
+   journal   = {Ecology},
+   pages     = {2603--2613},
+   year      = {2006},
+   volume    = {87}
+}
+
+@article{tiefelsdorf+griffith:07,
+   author    = {Tiefelsdorf, M. and Griffith, D. A.},
+   title     = {Semiparametric filtering of spatial autocorrelation: The eigenvector approach},
+   journal   = {Environment and Planning A},
+   pages     = {1193--1221},
+   year      = {2007},
+   volume    = {39}
+}
+
+@book{bivandetal:08,
+  author = {Roger S. Bivand and Edzer J. Pebesma and Virgilio G{\'o}mez-Rubio},
+  title = {Applied Spatial Data Analysis with {R}},
+  publisher = {Springer},
+  year = 2008,
+  address = {New York}
+}
+
+@article{bivandetal:09,
+   author = {R. S. Bivand and W. M\"{u}ller and M. Reder},
+   title = {Power Calculations for Global and Local {M}oran's {$I$}},
+   journal = {Computational Statistics and Data Analysis},
+   year = {2009},
+   volume = {53},
+   pages = {2859--2872}
+}
+
+@incollection{cliff+ord:69,
+author={Cliff, A. D. and J. K. Ord},
+year={1969},
+title={The problem of Spatial autocorrelation},
+booktitle={London Papers in Regional Science 1, Studies in Regional Science},
+editor={A. J. Scott},
+publisher={Pion},
+address={London},
+pages={25--55}
+}
+
+@book{cliff+ord:73,
+   author = {Cliff, A. D. and Ord, J. K.},
+   title = {Spatial Autocorrelation},
+   year = {1973},
+   publisher = {Pion},
+   address = {London}
+}
+
+@article{geary:54,
+   author = {Geary, R. C.},
+   title = {The contiguity ratio and statistical mapping},
+   year = {1954},
+   journal = {The Incorporated Statistician},
+   volume = {5},
+   pages = {115--145}
+}
+
+@article{joanes+gill:98,
+   author    = {Joanes D. N. and C. A. Gill},
+   title     = {Comparing measures of sample skewness and kurtosis},
+   journal   = {The Statistician},
+   pages     = {183--189},
+   year      = {1998},
+   volume    = {47}
+}
+
+@article{lietal:07,
+title = "Beyond {Moran's} {I}: testing for spatial dependence based on the spatial autoregressive model",
+journal = "Geographical Analysis",
+volume = "39",
+pages = "357--375",
+year = "2007",
+author = "Hongfei Li and Catherine A. Calder and Noel Cressie"
+}
+
+@article{moran:50,
+author={Moran, P. A. P.},
+title={Notes on continuous stochastic phenomena},
+journal={Biometrika},
+year={1950},
+volume={37},
+pages={17--23}
+}
+
+@book{tiefelsdorf:00,
+   author = {Tiefelsdorf, M.},
+   title = {Modelling Spatial Processes: The Identification and Analysis of Spatial Relationships in Regression Residuals by Means of {Moran}'s {$I$}},
+   publisher = {Springer},
+   address = {Berlin},
+   year = {2000}
+}
+
+@article{tiefelsdorf:02,
+   author = {Tiefelsdorf, M.},
+   title = {The Saddlepoint approximation of {Moran}'s {I} 
+     and local {Moran}'s ${I}_i$ reference distributions and their numerical
+     evaluation},
+   journal = {Geographical Analysis},
+   volume = {34},
+   pages = {187--206},
+   year = {2002},
+}
+
+@inproceedings{anselin+syabri+smirnov:2002,
+	title = {Visualizing multivariate spatial correlation with dynamically linked windows},
+	abstract = {Several recent efforts have focused on adding exploratory data analysis functionality to geographic information systems (GIS) by integrating established statistical software with a GIS. In this paper, we outline an alternative approach, where the functionality is built from scratch, using a combination of small libraries of dedicated functions, rather than relying on the full scope of existing software suites. The suggested approach is modular and freestanding. Within an overall framework of dynamically linked windows, it combines a cartographic representation of data on a map with traditional statistical graphics, such as histograms, box plots, and scatterplots. It extends earlier work on the visualization of spatial autocorrelation to a multivariate setting, introducing a Moran Scatterplot Matrix and Multivariate LISA Maps. The new program (DynESDA2) works on both point and polygon coverages, implements true brushing of maps, as well as the usual linking and brushing between maps and statistical graphs.},
+	booktitle = {University of {California}, {Santa} {Barbara}. {CD}-{ROM}},
+	author = {Anselin, Luc and Syabri, Ibnu and Smirnov, Oleg},
+	year = {2002}
+}

--- a/vignettes/sids.Rmd
+++ b/vignettes/sids.Rmd
@@ -5,7 +5,7 @@ output:
   html_document:
     toc: true
 vignette: >
-  %\VignetteIndexEntry{Creating Neighbours using sf objects}
+  %\VignetteIndexEntry{Introduction to the North Carolina SIDS data set (revised)}
   %\VignetteEngine{knitr::knitr}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/sids.Rmd
+++ b/vignettes/sids.Rmd
@@ -1,0 +1,462 @@
+---
+title: "Introduction to the North Carolina SIDS data set (revised)"
+author: "Roger Bivand"
+output:
+  html_document:
+    toc: true
+vignette: >
+  %\VignetteIndexEntry{Creating Neighbours using sf objects}
+  %\VignetteEngine{knitr::knitr}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+```
+
+## Introduction
+
+This data set was presented first in @symonsetal:1983, analysed with
+reference to the spatial nature of the data in @cressie+read:1985,
+expanded in @cressie+chan:1989, and used in detail in @cressie:1991. It
+is for the 100 counties of North Carolina, and includes counts of
+numbers of live births (also non-white live births) and numbers of
+sudden infant deaths, for the July 1, 1974 to June 30, 1978 and July 1,
+1979 to June 30, 1984 periods. In @cressie+read:1985, a listing of
+county neighbours based on shared boundaries (contiguity) is given, and
+in @cressie+chan:1989, and in @cressie:1991 [pp. 386–389], a different
+listing based on the criterion of distance between county seats, with a
+cutoff at 30 miles. The county seat location coordinates are given in
+miles in a local (unknown) coordinate reference system. The data are
+also used to exemplify a range of functions in the spatial statistics
+module user’s manual [@kaluznyetal:1996].
+
+## Getting the data into R 
+
+```{r, echo=FALSE,eval=TRUE,warning=FALSE, message=FALSE}
+library(spdep)
+```
+
+We will be using the **spdep** package, here version: `r spdep()[1]`, the **sp** package and the **maptools** package. The data from the sources
+refered to above is documented in the help page for the `nc.sids`
+data set in **spData**. The actual data, included in a shapefile of the county boundaries for North Carolina has been made available in the **maptools** package [^1]. These data are known to be geographical coordinates (longitude-latitude in decimal degrees) and are assumed to use the NAD27 datum.
+
+```{r echo=TRUE,eval=TRUE}
+library(sp)
+library(spdep)
+if (require(rgdal, quietly=TRUE)) {
+  nc <- readOGR(system.file("shapes/sids.shp", package="spData")[1])
+} else {
+  require(maptools, quietly=TRUE)
+  nc <- readShapeSpatial(system.file("shapes/sids.shp", package="spData")[1])
+}
+proj4string(nc) <- CRS("+proj=longlat +datum=NAD27")
+row.names(nc) <- as.character(nc$FIPSNO)
+```
+
+The shapefile format presupposes that you have three files with
+extensions `.shp`, `.shx`, and `.dbf`, where the first
+contains the geometry data, the second the spatial index, and the third
+the attribute data. They are required to have the same name apart from
+the extension, and are read here using `readShapeSpatial()` into the
+`SpatialPolygonsDataFrame` object `nc`; the class is defined in **sp**. The centroids of the largest polygon in each county are available
+using the `coordinates` method from **sp** as a two-column matrix, and can
+be used to place labels:
+
+```{r echo=TRUE}
+plot(nc, axes=TRUE)
+text(coordinates(nc), label=nc$FIPSNO, cex=0.5)
+```
+
+We can examine the names of the columns of the data frame to see what it
+contains — in fact some of the same columns that we will be examining
+below, and some others which will be useful in cleaning the data set.
+
+```{r echo=TRUE,eval=TRUE}
+names(nc)
+summary(nc)
+```
+
+We will now examine the data set reproduced from Cressie and
+collaborators, included in **spdep**, and add the neighbour relationships used in
+@cressie+chan:1989 to the background map as a graph shown in Figure
+\ref{plot-CC89.nb}:
+
+```{r echo=TRUE,eval=TRUE}
+gal_file <- system.file("weights/ncCR85.gal", package="spData")[1]
+ncCR85 <- read.gal(gal_file, region.id=nc$FIPSNO)
+ncCR85
+gal_file <- system.file("weights/ncCC89.gal", package="spData")[1]
+ncCC89 <- read.gal(gal_file, region.id=nc$FIPSNO)
+ncCC89
+```
+```{r label=plot-CC89.nb,fig.keep='none',echo=TRUE}
+plot(nc, border="grey")
+plot(ncCC89, coordinates(nc), add=TRUE, col="blue")
+```
+
+Printing the neighbour object shows that it is a neighbour list object,
+with a very sparse structure — if displayed as a matrix, only 3.94% of
+cells would be filled. Objects of class [`nb`]{} contain a list as long
+as the number of counties; each component of the list is a vector with
+the index numbers of the neighbours of the county in question, so that
+the neighbours of the county with [`region.id`]{} of [`37001`]{} can be
+retreived by matching against the indices. More information can be
+obtained by using [`summary()`]{} on an [`nb`]{} object. Finally, we
+associate a vector of names with the neighbour list, through the
+[`row.names`]{} argument. The names should be unique, as with data frame
+row names.
+
+```{r echo=TRUE}
+ncCC89
+r.id <- attr(ncCC89, "region.id")
+ncCC89[[match("37001", r.id)]]
+r.id[ncCC89[[match("37001", r.id)]]]
+``` 
+
+
+The neighbour list object records neighbours by their order in relation
+to the list itself, so the neighbours list for the county with
+[`region.id`]{} “37001” are the seventeenth, nineteenth, thirty-second,
+forty-first and sixty-eighth in the list. We can retreive their codes by
+looking them up in the [`region.id`]{} attribute.
+
+```{r echo=TRUE}
+as.character(nc$NAME)[card(ncCC89) == 0]
+```
+
+We should also note that this neighbour criterion generates two counties
+with no neighbours, Dare and Hyde, whose county seats were more than 30
+miles from their nearest neighbours. The [`card()`]{} function returns
+the cardinality of the neighbour set. We need to return to methods for
+handling no-neighbour objects later on. We will also show how new
+neighbours lists may be constructed in , and compare these with those
+from the literature.
+
+### Probability mapping
+
+Rather than review functions for measuring and modelling spatial
+dependence in the **spdep** package, we will focus on probability mapping for
+disease rates data. Typically, we have counts of the incidence of some
+disease by spatial unit, associated with counts of populations at risk.
+The task is then to try to establish whether any spatial units seem to
+be characterised by higher or lower counts of cases than might have been
+expected in general terms [@bailey+gatrell:1995].
+
+An early approach by @choynowski:1959, described by @cressie+read:1985
+and @bailey+gatrell:1995, assumes, given that the true rate for the
+spatial units is small, that as the population at risk increases to
+infinity, the spatial unit case counts are Poisson with mean value equal
+to the population at risk times the rate for the study area as a whole.
+Choynowski’s approach folds the two tails of the measured probabilities
+together, so that small values, for a chosen $\alpha$, occur for spatial
+units with either unusually high or low rates. For this reason, the high
+and low counties are plotted separately in Figure \ref{choymap}.
+
+```{r echo=TRUE}
+ch <- choynowski(nc$SID74, nc$BIR74)
+nc$ch_pmap_low <- ifelse(ch$type, ch$pmap, NA)
+nc$ch_pmap_high <- ifelse(!ch$type, ch$pmap, NA)
+prbs <- c(0,.001,.01,.05,.1,1)
+nc$high = cut(nc$ch_pmap_high, prbs)
+nc$low = cut(nc$ch_pmap_low,prbs )
+```
+```{r echo=TRUE}
+spplot(nc, c("low", "high"), col.regions=grey.colors(5))
+```
+
+For more complicated thematic maps, it may be helpful to use ColorBrewer
+(<http://colorbrewer.org>) colour palettes. Here we will only use the
+grey sequential palette, available in R in the **RColorBrewer** package (the colours are
+copied here to avoid loading the package).
+
+While the [`choynowski()`]{} function only provides the probability map
+values required, the [`probmap()`]{} function returns raw (crude) rates,
+expected counts (assuming a constant rate across the study area),
+relative risks, and Poisson probability map values calculated using the
+standard cumulative distribution function [`ppois()`]{}. This does not
+fold the tails together, so that counties with lower observed counts
+than expected, based on population size, have values in the lower tail,
+and those with higher observed counts than expected have values in the
+upper tail, as Figure \ref{poismap} shows.
+
+```{r echo=TRUE}
+pmap <- probmap(nc$SID74, nc$BIR74)
+nc$pmap <- pmap$pmap
+brks <- c(0,0.001,0.01,0.025,0.05,0.95,0.975,0.99,0.999,1)
+library(RColorBrewer)
+``` 
+```{r echo=TRUE}
+spplot(nc, "pmap", at=brks, col.regions=rev(brewer.pal(9, "RdBu")))
+```
+
+Marilia Carvalho (personal communication) and Virgilio Gómez Rubio
+[@gomez-rubio+ferrandiz+lopez:2003] have pointed to the unusual shape of
+the distribution of the Poisson probability values (Figure
+\ref{poishist}), repeating the doubts about probability mapping voiced by
+@cressie:1991 [p. 392]: “an extreme value $\ldots$ may be more due to
+its lack of fit to the Poisson model than to its deviation from the
+constant rate assumption”. There are many more high values than one
+would have expected, suggesting perhaps overdispersion, that is that the
+ratio of the variance and mean is larger than unity.
+
+```{r label=poishist,fig.keep='none',echo=TRUE}
+hist(nc$pmap, main="")
+```
+
+One ad-hoc way to assess the impact of the possible failure of our
+assumption that the counts follow the Poisson distribution is to
+estimate the dispersion by fitting a generalized linear model of the
+observed counts including only the intercept (null model) and offset by
+the observed population at risk (suggested by Marilia Carvalho and
+associates):
+
+```{r echo=TRUE}
+res <- glm(SID74 ~ offset(log(BIR74)), data=nc, family="quasipoisson")
+nc$stdres <- rstandard(res)
+brks <- c(-4, -3, -2, -1.5, -1, -0.5, 0.5, 1, 1.5, 2, 3, 4)
+```
+```{r echo=TRUE}
+spplot(nc, "stdres", at=brks, col.regions=rev(brewer.pal(11, "RdBu")))
+```
+
+The dispersion is equal to 2.2786, much greater than unity; we calculate
+the corrected probability map values by taking the standardised
+residuals of the model, taking the size of the dispersion into account;
+the results are shown in Figure \ref{poismap2}. Many fewer counties appear
+now to have unexpectedly large or small numbers of cases. This is an
+ad-hoc adjustment made because R provides access to a wide range of
+model-fitting functions that can be used to help check our assumptions.
+@gomez-rubio+ferrandiz+lopez:2003 chose rather to construct a
+probability map under the hypothesis that data are drawn from a Negative
+Binomial distribution.
+
+So far, none of the maps presented have made use of the spatial
+dependence possibly present in the data. A further elementary step that
+can be taken is to map Empirical Bayes estimates of the rates, which are
+smoothed in relation to the raw rates. The underlying question here is
+linked to the larger variance associated with rate estimates for
+counties with small populations at risk compared with counties with
+large populations at risk. Empirical Bayes estimates place more credence
+on the raw rates of counties with large populations at risk, and modify
+them much less than they modify rates for small counties. In the case of
+small populations at risk, more confidence is placed in either the
+global rate for the study area as a whole, or for local Empirical Bayes
+estimates, in rates for a larger moving window including the neighbours
+of the county being estimated. The function used for this in **spdep** is
+[`EBlocal()`]{}, initially contributed by Marilia Carvalho. It parallels
+a similar function in GeoDa, but uses the @bailey+gatrell:1995
+interpretation of @marshall:1991, rather than that in GeoDa
+[@anselin+syabri+smirnov:2002].
+
+```{r echo=TRUE}
+global_rate <- sum(nc$SID74)/sum(nc$BIR74)
+nc$Expected <- global_rate * nc$BIR74
+res <- EBlocal(nc$SID74, nc$Expected, ncCC89, zero.policy=TRUE)
+nc$EB_loc <- res$est
+brks <- c(0, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5)
+spl <- list("sp.text", loc=coordinates(nc)[card(ncCC89) == 0,], txt=rep("*", 2), cex=1.2)
+```
+```{r echo=TRUE}
+spplot(nc, "EB_loc", at=brks, col.regions=rev(brewer.pal(8, "RdBu")), sp.layout=spl)
+```
+The results are shown in Figure \ref{EBlocal}. Like other relevant
+functions in **spdep**,`EBlocal()` takes a `zero.policy`
+argument to allow missing values to be passed through. In this case,
+no local estimate is available for the two counties with no neighbours,
+marked by stars.
+
+In addition to Empirical Bayes smoothing globally, used both for disease
+mapping and the Assun[c]{}ão and Reis correction to Moran’s $I$ for
+rates data (to shrink towards the global rate when the population at
+risk is small, here as a Monte Carlo test), lists of local neighbours
+can be used to shrink towards a local rate.
+
+```{r echo=TRUE}
+set.seed(1)
+EBImoran.mc(nc$SID74, nc$BIR74, nb2listw(ncCC89, style="B", zero.policy=TRUE), nsim=999, zero.policy=TRUE)
+```
+
+## Exploration and modelling of the data
+
+One of the first steps taken by @cressie+read:1985 is to try to bring
+out spatial trends by dividing North Carolina up into $4\times4$ rough
+rectangles. Just to see how this works, let us map these rough
+rectangles before proceeding further (see Figure \ref{LMmap}).
+
+```{r echo=TRUE}
+nc$both <- factor(paste(nc$L_id, nc$M_id, sep=":"))
+nboth <- length(table(unclass(nc$both)))
+``` 
+```{r echo=TRUE,eval=FALSE}
+spplot(nc, "both", col.regions=sample(rainbow(nboth)))
+```
+
+Cressie constructs a transformed SIDS rates variable, 1974–78, for his
+analyses (with co-workers). We can replicate his stem-and-leaf figure on
+p. 396 in the book, taken from @cressie+read:1989:
+
+```{r echo=TRUE}
+nc$ft.SID74 <- sqrt(1000)*(sqrt(nc$SID74/nc$BIR74) + sqrt((nc$SID74+1)/nc$BIR74))
+stem(round(nc$ft.SID74, 1), scale=2)
+```
+
+```{r echo=FALSE}
+print(spplot(nc, "both", col.regions=sample(rainbow(nboth))))
+```
+
+### Median polish smoothing {#medpol}
+
+@cressie:1991 [pp. 46–48, 393–400] discusses in some detail how
+smoothing may be used to partition the variation in the data into smooth
+and rough. In order to try it out on the North Carolina SIDS data set,
+we will use a coarse gridding into four columns and four rows given by
+@cressie:1991 [pp. 553–554], where four grid cells are empty; these are
+given by variables [`L_id`]{} and [`M_id`]{} in object [`nc`]{}. Next we
+aggregate the number of live births and the number of SIDS cases
+1974–1978 for the grid cells:
+
+```{r echo=TRUE,eval=TRUE}
+mBIR74 <- tapply(nc$BIR74, nc$both, sum)
+mSID74 <- tapply(nc$SID74, nc$both, sum)
+```
+
+Using the same Freeman-Tukey transformation as is used for the county
+data, we coerce the data into a correctly configured matrix, some of the
+cells of which are empty. The [`medpolish`]{} function is applied to the
+matrix, being told to remove empty cells; the function iterates over the
+rows and columns of the matrix using [`median`]{} to extract an overall
+effect, row and column effects, and residuals:
+
+```{r echo=TRUE,eval=TRUE}
+mFT <- sqrt(1000)*(sqrt(mSID74/mBIR74) + sqrt((mSID74+1)/mBIR74))
+mFT1 <- t(matrix(mFT, 4, 4, byrow=TRUE))
+med <- medpolish(mFT1, na.rm=TRUE, trace.iter=FALSE)
+med
+```
+
+Returning to the factors linking rows and columns to counties, and
+generating matrices of dummy variables using [`model.matrix`]{}, we can
+calculate fitted values of the Freeman-Tukey adjusted rate for each
+county, and residuals by subtracting the fitted value from the observed
+rate. Naturally, the fitted value will be the same for counties in the
+same grid cell:
+
+```{r echo=TRUE,eval=TRUE}
+mL_id <- model.matrix(~ as.factor(nc$L_id) -1)
+mM_id <- model.matrix(~ as.factor(nc$M_id) -1)
+nc$pred <- c(med$overall + mL_id %*% med$row + mM_id %*% med$col)
+nc$mp_resid <- nc$ft.SID74 - nc$pred
+```
+```{r label=medpolfig,fig.keep='none',echo=TRUE,eval=FALSE}
+cI_ft <- pretty(nc$ft.SID74, n=9)
+pal_ft <- colorRampPalette(brewer.pal(6, "YlOrBr"))(length(cI_ft)-1)
+p1 <- spplot(nc, c("ft.SID74"), col.regions=pal_ft, at=cI_ft, col="grey30", main="FT transformed SIDS rate")
+p2 <- spplot(nc, c("pred"), col.regions=pal_ft, at=cI_ft, col="grey30", main="Median-polish fit")
+atn <- pretty(nc$mp_resid[nc$mp_resid < 0])
+atp <- pretty(nc$mp_resid[nc$mp_resid >= 0])
+pal <- c(rev(brewer.pal(length(atn-1), "YlOrRd")), brewer.pal(length(atp[-1]), "YlGnBu")[-1])
+p3 <- spplot(nc, "mp_resid", at=c(atn, atp[-1]), col.regions=pal, col="grey30", main="Median-polish residuals")
+plot(p1, split=c(1,1,1,3), more=TRUE)
+plot(p2, split=c(1,2,1,3), more=TRUE)
+plot(p3, split=c(1,3,1,3), more=FALSE)
+```
+
+Figure \ref{fig:med\_pol} shows the median polish smoothing results as
+three maps, the observed Freeman-Tukey transformed SIDS rates, the
+fitted smoothed values, and the residuals. In addition, a plot for the
+median polish object is also shown, plotting the smooth residuals
+against the outer product of the row and column effects divided by the
+overall effect, which would indicate a lack of additivity between row
+and column if this was the case — this is more relevant for analysis of
+tables of covariates rather than geographical grids.
+
+### CAR model fitting
+
+We will now try to replicate three of the four models fitted by
+[@cressie+chan:1989] to the transformed rates variable. The first thing
+to do is to try to replicate their 30 mile distance between county seats
+neighbours, which almost works. From there we try to reconstruct three
+of the four models they fit, concluding that we can get quite close, but
+that a number of questions are raised along the way.
+
+Building the weights is much more complicated, because they use a
+combination of distance-metric and population-at-risk based weights, but
+we can get quite close [see also @kaluznyetal:1996]:
+
+```{r echo=TRUE}
+sids.nhbr30.dist <- nbdists(ncCC89, cbind(nc$east, nc$north))
+sids.nhbr <- listw2sn(nb2listw(ncCC89, glist=sids.nhbr30.dist, style="B", zero.policy=TRUE))
+dij <- sids.nhbr[,3]
+n <- nc$BIR74
+el1 <- min(dij)/dij
+el2 <- sqrt(n[sids.nhbr$to]/n[sids.nhbr$from])
+sids.nhbr$weights <- el1*el2
+sids.nhbr.listw <- sn2listw(sids.nhbr)
+```
+
+The first model (I) is a null model with just an intercept, the second
+(II) includes all the 12 parcels of contiguous counties in 4 east-west
+and 4 north-south bands, while the fourth (IV) includes the transformed
+non-white birth-rate:
+
+```{r echo=TRUE}
+nc$ft.NWBIR74 <- sqrt(1000)*(sqrt(nc$NWBIR74/nc$BIR74) + sqrt((nc$NWBIR74+1)/nc$BIR74))
+```
+
+Cressie identifies Anson county as an outlier, and drops it from further
+analysis. Because the weights are constructed in a complicated way, they
+will be subsetted by dropping the row and column of the weights matrix:
+
+```{r echo=TRUE}
+lm_nc <- lm(ft.SID74 ~ 1, data=nc)
+outl <- which.max(rstandard(lm_nc))
+as.character(nc$names[outl])
+W <- listw2mat(sids.nhbr.listw)
+W.4 <- W[-outl, -outl]
+sids.nhbr.listw.4 <- mat2listw(W.4)
+nc2 <- nc[!(1:length(nc$CNTY_ID) %in% outl),]
+``` 
+
+It appears that both numerical issues (convergence in particular) and
+uncertainties about the exact spatial weights matrix used make it
+difficult to reproduce the results of @cressie+chan:1989, also given in
+@cressie:1991. We now try to replicate them for the null weighted CAR
+model (Cressie has intercept 2.838, $\hat{\theta}$ 0.833, for k=1):
+
+```{r echo=TRUE}
+ecarIaw <- spautolm(ft.SID74 ~ 1, data=nc2, listw=sids.nhbr.listw.4, weights=BIR74, family="CAR")
+summary(ecarIaw)
+```
+
+The spatial parcels model also seems to work, with Cressie's $\hat{\theta}$ 0.710, and the other coefficients agreeing more or less by rank:
+
+```{r echo=TRUE}
+ecarIIaw <- spautolm(ft.SID74 ~ both - 1, data=nc2, listw=sids.nhbr.listw.4, weights=BIR74, family="CAR")
+summary(ecarIIaw)
+```
+
+Finally, the non-white model repeats Cressie’s finding that much of the
+variance of the transformed SIDS rate for 1974–8 can be accounted for by
+the transformed non-white birth variable (Cressie intercept 1.644,
+$\hat{b}$ 0.0346, $\hat{\theta}$ 0.640 — not significant):
+
+```{r echo=TRUE}
+ecarIVaw <- spautolm(ft.SID74 ~ ft.NWBIR74, data=nc2, listw=sids.nhbr.listw.4, weights=BIR74, family="CAR")
+summary(ecarIVaw)
+```
+
+```{r echo=TRUE}
+nc2$fitIV <- fitted.values(ecarIVaw)
+```
+```{r echo=TRUE,eval=FALSE}
+spplot(nc2, "fitIV", cuts=12, col.regions=grey.colors(13, 0.9, 0.3))
+```
+
+```{r echo=TRUE}
+ecarIawll <- spautolm(ft.SID74 ~ 1, data=nc2, listw=sids.nhbr.listw.4, weights=BIR74, family="CAR", llprof=seq(-0.1, 0.9020532358, length.out=100))
+plot(ll ~ lambda, ecarIawll$llprof, type="l")
+```
+
+[^1]: These data are taken with permission from:
+    <http://sal.agecon.uiuc.edu/datasets/sids.zip>.

--- a/vignettes/sids.Rmd
+++ b/vignettes/sids.Rmd
@@ -4,6 +4,7 @@ author: "Roger Bivand"
 output:
   html_document:
     toc: true
+bibliography: refs.bib
 vignette: >
   %\VignetteIndexEntry{Introduction to the North Carolina SIDS data set (revised)}
   %\VignetteEngine{knitr::knitr}
@@ -457,6 +458,8 @@ spplot(nc2, "fitIV", cuts=12, col.regions=grey.colors(13, 0.9, 0.3))
 ecarIawll <- spautolm(ft.SID74 ~ 1, data=nc2, listw=sids.nhbr.listw.4, weights=BIR74, family="CAR", llprof=seq(-0.1, 0.9020532358, length.out=100))
 plot(ll ~ lambda, ecarIawll$llprof, type="l")
 ```
+
+## References
 
 [^1]: These data are taken with permission from:
     <http://sal.agecon.uiuc.edu/datasets/sids.zip>.


### PR DESCRIPTION
Thought I'd go ahead and start a PR for this. Things I'm going to add to this PR before it's ready to merge (this is an incomplete PR):

- Fix citations (need to add .bib files for each Rmd). I can produce these quickly in Zotero, but maybe @rsbivand you already have the citations, in any of these [file formats](https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#specifying_a_bibliography)?
- Fix figure references
- Figure out what's going on with not being able to load data from `etc/backstore/*.RData` in `CO69.Rmd`, line 518 and `SpatialFiltering.Rmd`, line 90

And then we'll have a nice set of `Rmd`-ify-ed vignettes to include on the pkgdown site!