### PR TITLE
subset.nb: Also subset IDs in names attribute

### DIFF
--- a/R/subset.nb.R
+++ b/R/subset.nb.R
@@ -31,7 +31,11 @@ subset.nb <- function(x, subset, ...) {
     attr(z, "region.id") <- reg.id
     for (i in 1:length(xattrs)) {
 	if (xattrs[i] != "region.id")
+	    if(xattrs[i] == "names") {
+	       attr(z, xattrs[i]) <- subset.default(attr(x, xattrs[i]), subset)
+        } else {
 	    attr(z, xattrs[i]) <- attr(x, xattrs[i])
+        }
     }
     z <- sym.attr.nb(z)
     z


### PR DESCRIPTION
When using IDs in an nb object subsetting leads to an error

> names attribute [old length] must be same length as vector [new length]

This is because subset.nb uses temporary IDs throughout and at the end
overwrites these with the IDs chosen by the user (if set). These are
however not subsetted an therefore we try to overwrite the 'names' attr
of [new length] with user IDs of [old length].

Commit adds an if-clause to the attribute setting that subsets the IDs.

Tracked by #34 