### PR TITLE
fix partially matched argument name

### DIFF
--- a/R/nb2listw.R
+++ b/R/nb2listw.R
@@ -19,7 +19,7 @@ nb2listw <- function(neighbours, glist=NULL, style="W", zero.policy=NULL)
 		glist <- vector(mode="list", length=n)
 		for (i in 1:n)
 			if(cardnb[i] > 0) {
-				glist[[i]] <- rep(1, length=cardnb[i])
+				glist[[i]] <- rep(1, cardnb[i])
 				mode(glist[[i]]) <- "numeric"
 			}
 		attr(vlist, "mode") <- "binary"


### PR DESCRIPTION
A trivial fix to avoid numerous warnings of the form

```
50: In rep(1, length = cardnb[i]) :
  partial argument match of 'length' to 'length.out'
```

when running `nb2listw()` (e.g., `example(nb2listw)`) under `options(warnPartialMatchArgs = TRUE)`.
