### PR TITLE
Adding additional Sokal 1998 calculations for Moran I_i (reflow)

### DIFF
--- a/R/localmoran.R
+++ b/R/localmoran.R
@@ -1,7 +1,7 @@
 # Copyright 2001-18 by Roger Bivand
 #
 
-localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail, conditional=TRUE, 
+localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail, conditional=FALSE, 
 	alternative = "greater", p.adjust.method="none", mlvar=TRUE,
 	spChk=NULL, adjust.x=FALSE) {
         stopifnot(is.vector(x))

--- a/R/localmoran.R
+++ b/R/localmoran.R
@@ -1,7 +1,7 @@
 # Copyright 2001-18 by Roger Bivand
 #
 
-localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail, 
+localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail, conditional=TRUE, 
 	alternative = "greater", p.adjust.method="none", mlvar=TRUE,
 	spChk=NULL, adjust.x=FALSE) {
         stopifnot(is.vector(x))
@@ -58,8 +58,12 @@ localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail,
         }
 	res[,1] <- (z/s2) * lz
 	Wi <- sapply(listw$weights, sum) 
-	res[,2] <- -Wi / (n-1) 
-
+	if (conditional){	
+	  m2 <- sum(z * z) / n
+	  res[, 2] <- -(z ** 2 * Wi) / ((n - 1) * m2)
+	} else {
+	  res[, 2] <- -Wi / (n-1) 
+	}  
 	if (mlvar)  {
           if (adjust.x) {
             b2 <- (sum(z[nc]^4, na.rm=NAOK)/sum(nc))/(s2^2)
@@ -77,7 +81,14 @@ localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail,
 	Wi2 <- sapply(listw$weights, function(x) sum(x^2)) 
 	A <- (n-b2) / (n-1)
 	B <- (2*b2 - n) / ((n-1)*(n-2))
-        res[,3] <- A*Wi2 + B*(Wi^2 - Wi2) - res[,2]^2
+	if (conditional){
+	  res[, 3] <- ((z / m2) ** 2 *
+	                 (n / (n - 2)) *
+	                 (Wi2 - (Wi ** 2 / (n - 1))) *
+	                 (m2 - (z ** 2 / (n - 1))))
+	} else {
+	  res[,3] <- A*Wi2 + B*(Wi^2 - Wi2) - res[,2]^2
+	}
 # Changed to Sokal (1998) VIi
 #	 C <- Wi^2 / ((n-1)^2) # == res[,2]^2
 #	 Wikh2 <- sapply(listw$weights, function(x) {
@@ -85,11 +96,13 @@ localmoran <- function(x, listw, zero.policy=NULL, na.action=na.fail,
 #	 })
 #        res[,3] <- A*Wi2 + B*Wikh2 - C
 	res[,4] <- (res[,1] - res[,2]) / sqrt(res[,3])
-        if (alternative == "two.sided") pv <- 2 * pnorm(abs(res[,4]), 
-	    lower.tail=FALSE)
-        else if (alternative == "greater")
-            pv <- pnorm(res[,4], lower.tail=FALSE)
-        else pv <- pnorm(res[,4])
+	if (alternative == "two.sided") {
+	  pv <- 2 * pnorm(abs(res[,4]), lower.tail=FALSE)
+	} else if (alternative == "greater") {
+	  pv <- pnorm(res[,4], lower.tail=FALSE)
+	} else {
+	  pv <- pnorm(res[,4])
+	}
 	res[,5] <- p.adjustSP(pv, listw$neighbours, method=p.adjust.method)
 	if (!is.null(na.act) && excl) {
 		res <- naresid(na.act, res)

--- a/man/localmoran.Rd
+++ b/man/localmoran.Rd
@@ -11,7 +11,7 @@ used as a diagnostic tool. The statistic is:
 and its expectation and variance are given in Anselin (1995).
 }
 \usage{
-localmoran(x, listw, zero.policy=NULL, na.action=na.fail, 
+localmoran(x, listw, zero.policy=NULL, na.action=na.fail, conditional=TRUE,
 	alternative = "greater", p.adjust.method="none", mlvar=TRUE,
         spChk=NULL, adjust.x=FALSE)
 localmoran_perm(x, listw, nsim=499, zero.policy=NULL, na.action=na.fail, 
@@ -23,6 +23,7 @@ localmoran_perm(x, listw, nsim=499, zero.policy=NULL, na.action=na.fail,
   \item{listw}{a \code{listw} object created for example by \code{nb2listw}}
   \item{zero.policy}{default NULL, use global option value; if TRUE assign zero to the lagged value of zones without neighbours, if FALSE assign NA}
   \item{na.action}{a function (default \code{na.fail}), can also be \code{na.omit} or \code{na.exclude} - in these cases the weights list will be subsetted to remove NAs in the data. It may be necessary to set zero.policy to TRUE because this subsetting may create no-neighbour observations. Note that only weights lists created without using the glist argument to \code{nb2listw} may be subsetted. If \code{na.pass} is used, zero is substituted for NA values in calculating the spatial lag. (Note that na.exclude will only work properly starting from R 1.9.0, na.omit and na.exclude assign the wrong classes in 1.8.*)}
+  \item{conditional}{default TRUE: expectation and variance are calculated using the conditional randomization null (Sokal 1998 Eqs. A7 & A8). If FALSE: expectation and variance are calculated using the total randomization null (Sokal 1998 Eqs. A3 & A4).}
   \item{alternative}{a character string specifying the alternative hypothesis, must be one of greater (default), less or two.sided.}
   \item{p.adjust.method}{a character string specifying the probability value adjustment for multiple tests, default "none"; see \code{\link{p.adjustSP}}. Note that the number of multiple tests for each region is only taken as the number of neighbours + 1 for each region, rather than the total number of regions.}
   \item{mlvar}{default TRUE: values of local Moran's I are reported using the variance of the variable of interest (sum of squared deviances over n), but can be reported as the sample variance, dividing by (n-1) instead; both are used in other implementations.}
@@ -34,7 +35,7 @@ localmoran_perm(x, listw, nsim=499, zero.policy=NULL, na.action=na.fail,
 }
 
 \details{
-The values of local Moran's I are divided by the variance (or sample variance) of the variable of interest to accord with Table 1, p. 103, and formula (12), p. 99, in Anselin (1995), rathar than his formula (7), p. 98. The variance of the local Moran statistic is taken from Sokal et al. (1998), equation 5 p. 334 and A4*, p. 351. By default, the implementation divides by n, not (n-1) in calculating the variance and higher moments.
+The values of local Moran's I are divided by the variance (or sample variance) of the variable of interest to accord with Table 1, p. 103, and formula (12), p. 99, in Anselin (1995), rathar than his formula (7), p. 98. The variance of the local Moran statistic is taken from Sokal et al. (1998) p. 334, equations 4 & 5 or equations 7 & 8 located depending on user specification. By default, the implementation divides by n, not (n-1) in calculating the variance and higher moments.
 }
 
 \value{

--- a/man/localmoran.Rd
+++ b/man/localmoran.Rd
@@ -23,7 +23,7 @@ localmoran_perm(x, listw, nsim=499, zero.policy=NULL, na.action=na.fail,
   \item{listw}{a \code{listw} object created for example by \code{nb2listw}}
   \item{zero.policy}{default NULL, use global option value; if TRUE assign zero to the lagged value of zones without neighbours, if FALSE assign NA}
   \item{na.action}{a function (default \code{na.fail}), can also be \code{na.omit} or \code{na.exclude} - in these cases the weights list will be subsetted to remove NAs in the data. It may be necessary to set zero.policy to TRUE because this subsetting may create no-neighbour observations. Note that only weights lists created without using the glist argument to \code{nb2listw} may be subsetted. If \code{na.pass} is used, zero is substituted for NA values in calculating the spatial lag. (Note that na.exclude will only work properly starting from R 1.9.0, na.omit and na.exclude assign the wrong classes in 1.8.*)}
-  \item{conditional}{default TRUE: expectation and variance are calculated using the conditional randomization null (Sokal 1998 Eqs. A7 & A8). If FALSE: expectation and variance are calculated using the total randomization null (Sokal 1998 Eqs. A3 & A4).}
+  \item{conditional}{default FALSE: expectation and variance are calculated using the total randomization null (Sokal 1998 Eqs. A3 & A4). If TRUE: expectation and variance are calculated using the conditional randomization null (Sokal 1998 Eqs. A7 & A8). Elaboration of these changes available in Sauer 2021.}
   \item{alternative}{a character string specifying the alternative hypothesis, must be one of greater (default), less or two.sided.}
   \item{p.adjust.method}{a character string specifying the probability value adjustment for multiple tests, default "none"; see \code{\link{p.adjustSP}}. Note that the number of multiple tests for each region is only taken as the number of neighbours + 1 for each region, rather than the total number of regions.}
   \item{mlvar}{default TRUE: values of local Moran's I are reported using the variance of the variable of interest (sum of squared deviances over n), but can be reported as the sample variance, dividing by (n-1) instead; both are used in other implementations.}
@@ -52,7 +52,9 @@ Geographical Analysis, 27, 93--115;
 Getis, A. and Ord, J. K. 1996 Local spatial
 statistics: an overview. In P. Longley and M. Batty (eds) \emph{Spatial
 analysis: modelling in a GIS environment} (Cambridge: Geoinformation
-International), 261--277; Sokal, R. R, Oden, N. L. and Thomson, B. A. 1998. Local Spatial Autocorrelation in a Biological Model. Geographical Analysis, 30. 331--354; Bivand RS, Wong DWS 2018 Comparing implementations of global and local indicators of spatial association. TEST, 27(3), 716--748 \doi{10.1007/s11749-018-0599-x}}
+International), 261--277; Sokal, R. R, Oden, N. L. and Thomson, B. A. 1998. Local Spatial Autocorrelation in a Biological Model. Geographical Analysis, 30. 331--354; 
+Bivand RS, Wong DWS 2018 Comparing implementations of global and local indicators of spatial association. TEST, 27(3), 716--748 \doi{10.1007/s11749-018-0599-x}; 
+Sauer, J., Oshan, T. M., Rey, S., & Wolf, L. J. 2021. On Null Hypotheses and Heteroskedasticity. OSF Preprints. \doi{doi:10.31219/osf.io/ugkhp}}
 \author{Roger Bivand \email{Roger.Bivand@nhh.no}}
 
 \seealso{\code{\link{localG}}}


### PR DESCRIPTION
Apologies for the double PR. A spacing issue on my end made it seem the entire file had been changed. 

_Same PR information from https://github.com/r-spatial/spdep/pull/57_

This PR adds additional Sokal 1998 calculations to the spdep localmoran function. These calculations distinguish between 'conditional' and 'total' randomization hypotheses (e.g., whether or not a value of z at site i is fixed).

The PR adds a TRUE/FALSE argument called conditional. Defaulted to conditional=TRUE, E.Ii and Var.Ii results are calculated using Sokal 1998 Eqs 7 and 8. If conditional=FALSE, E.Ii and Var.Ii columns are calculated using the existing Sokal 1998 Eqs 4 and 5. Ii, Z.Ii, and Pr(z > 0) are calculated as usual. This preserves the existing results structure of localmoran and avoids adding additional columns.

The localmoran.Rd file has also been updated. These changes have not yet been extended to the new localmoran_perm function.

This PR was built with @ljwolf.

Open to suggestions and guidance on the preferred way to incorporate these changes!