### PR TITLE
implement global moran bivariate

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,11 +32,11 @@ export(EBImoran.mc, probmap, choynowski, EBest, EBlocal)
 
 export(airdist, card, cell2nb, vi2mrc, n.comp.nb, diffnb, dnearneigh, droplinks)
 
-export(gabrielneigh, geary.test, geary, geary.mc, globalG.test, graph2nb, 
+export(gabrielneigh, geary.test, geary, geary.mc, globalG.test, graph2nb,
 	joincount.test, joincount.mc, joincount.multi, print.jcmulti,
 	knearneigh, knn2nb)
 
-export(listw2sn, sn2listw, read.gwt2nb,	write.sn2gwt, lm.LMtests, 
+export(listw2sn, sn2listw, read.gwt2nb,	write.sn2gwt, lm.LMtests,
 	lm.morantest, localG, localG_perm, localmoran, localmoran_perm, moran,
 	moran.test, moran.mc, moran.plot, localmoran.sad, lm.morantest.sad,
 	nb2listw, nb2listwdist, nb2mat, listw2mat, mat2listw, nbdists, nblag,
@@ -45,16 +45,16 @@ export(listw2sn, sn2listw, read.gwt2nb,	write.sn2gwt, lm.LMtests,
 	get.spChkOption, spNamedVec, tri2nb,
 	spweights.constants, lag.listw, listw2U, listw2star, is.symmetric.nb,
 	sym.attr.nb, include.self, make.sym.nb, union.nb, intersect.nb,
-	setdiff.nb, complement.nb, Szero, spdep, print.nb, summary.nb, 
+	setdiff.nb, complement.nb, Szero, spdep, print.nb, summary.nb,
 	plot.nb, edit.nb, subset.nb, summary.listw, print.listw, subset.listw,
-	plot.Gabriel, plot.relative, print.jclist, print.LMtestlist, 
-	plot.mc.sim, as.data.frame.localmoransad, print.localmoransad, 
-	summary.localmoransad, print.summary.localmoransad, print.moransad, 
+	plot.Gabriel, plot.relative, print.jclist, print.LMtestlist,
+	plot.mc.sim, as.data.frame.localmoransad, print.localmoransad,
+	summary.localmoransad, print.summary.localmoransad, print.moransad,
 	summary.moransad, print.summary.moransad, print.spcor, plot.spcor,
         remove.self)
 
 export(write.sn2dat, read.dat2listw, nb2blocknb, p.adjustSP,
-	is.symmetric.glist, nb2lines, listw2lines, df2sn, 
+	is.symmetric.glist, nb2lines, listw2lines, df2sn,
 	plot.listw, aggregate.nb, old.make.sym.nb)
 
 export(nb2WB, listw2WB, nb2INLA)
@@ -75,11 +75,12 @@ export(grid2nb)
 
 export(autocov_dist)
 
-export(set.VerboseOption, get.VerboseOption, set.ZeroPolicyOption, 
+export(set.VerboseOption, get.VerboseOption, set.ZeroPolicyOption,
         get.ZeroPolicyOption)
 export(set.mcOption, get.mcOption, set.coresOption, get.coresOption,
         set.ClusterOption, get.ClusterOption)
 
+export(moran_bv)
 
 
 S3method(print, nb)

--- a/R/moran-bv.R
+++ b/R/moran-bv.R
@@ -1,49 +1,20 @@
-# calculate the bivariate moran
-moran_bv_calc <- function(x, yj, wt) {
-  numerator <- sum(mapply(function(wij, yj, xi) sum(wij * yj * xi),
-                          wt, yj, x))
-  denominator <- sum(x^2)
-
-  numerator / denominator
-}
-
-
-# a listw implementation to make permutation easier
-moran_bv_impl <- function(x, y, listw) {
-
-  nb <- listw[["neighbours"]]
-  wt <- listw[["weights"]]
-
-  yj <- find_xj(y, nb)
-
-  moran_bv_calc(x, yj, wt)
-
-}
-
-
 moran_bv <- function(x, y, listw, nsim = 99, scale = TRUE) {
-
   # variables should always be centered and scaled
   if (scale) {
     x <- scale(x)
     y <- scale(y)
   }
 
-  # pull out weights and nbs for observed calc
-  nb <- listw[["neighbours"]]
-  wt <- listw[["weights"]]
-
-  # calculate observed bivariate moran
-  obs <- moran_bv_calc(x, find_xj(y, nb),  wt)
+  obs <- sum(lag.listw(listw, y) * x) / sum(x ^ 2)
 
   # create simulated distribution using permuted listw object
   reps <- replicate(
     nsim,
-    moran_bv_impl(x, y, permute_listw(listw))
-    )
+    sum(lag.listw(permute_listw(listw), y) * x) / sum(x ^ 2)
+  )
 
   # calculate p-value from replicates
-  p_sim <- (sum(obs <= reps) + 1 )/ (nsim + 1)
+  p_sim <- (sum(obs <= reps) + 1 ) / (nsim + 1)
 
   list("Ib" = obs,
        # folded p-sim

--- a/R/moran-bv.R
+++ b/R/moran-bv.R
@@ -1,0 +1,52 @@
+# calculate the bivariate moran
+moran_bv_calc <- function(x, yj, wt) {
+  numerator <- sum(mapply(function(wij, yj, xi) sum(wij * yj * xi),
+                          wt, yj, x))
+  denominator <- sum(x^2)
+
+  numerator / denominator
+}
+
+
+# a listw implementation to make permutation easier
+moran_bv_impl <- function(x, y, listw) {
+
+  nb <- listw[["neighbours"]]
+  wt <- listw[["weights"]]
+
+  yj <- find_xj(y, nb)
+
+  moran_bv_calc(x, yj, wt)
+
+}
+
+
+moran_bv <- function(x, y, listw, nsim = 99, scale = TRUE) {
+
+  # variables should always be centered and scaled
+  if (scale) {
+    x <- scale(x)
+    y <- scale(y)
+  }
+
+  # pull out weights and nbs for observed calc
+  nb <- listw[["neighbours"]]
+  wt <- listw[["weights"]]
+
+  # calculate observed bivariate moran
+  obs <- moran_bv_calc(x, find_xj(y, nb),  wt)
+
+  # create simulated distribution using permuted listw object
+  reps <- replicate(
+    nsim,
+    moran_bv_impl(x, y, permute_listw(listw))
+    )
+
+  # calculate p-value from replicates
+  p_sim <- (sum(obs <= reps) + 1 )/ (nsim + 1)
+
+  list("Ib" = obs,
+       # folded p-sim
+       p_sim = pmin(p_sim, 1 - p_sim)
+  )
+}

--- a/R/utils-cond-permute.R
+++ b/R/utils-cond-permute.R
@@ -1,0 +1,26 @@
+# Conditional Permutation -------------------------------------------------
+
+# Conditionally permutes a listw object
+permute_listw <- function(listw) {
+  n <- length(listw$neighbours)
+
+  cards <- lengths(listw$neighbours)
+  # Shuffle the neighbors by randomly sampling from all possible neighbors
+  # except where x exists
+  perm_nb <- mapply(shuffle_nbs, 1:n, n, cards, SIMPLIFY = FALSE)
+  class(perm_nb) <- c("nb", "list")
+  listw$neighbours <- perm_nb
+
+  listw
+}
+
+# Internal function to shuffle neighbors
+#
+# Used in conditional permutation and the function `permute_listw()`.
+# i is the index position of observation `i`
+# n is the length of neighbor list
+# card is the cardinality for observation i
+shuffle_nbs <- function(i, n, card) {
+  x <- 1:n
+  sample(x[-i], size = card)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-# Copyright 2001-15 by Roger Bivand 
+# Copyright 2001-15 by Roger Bivand
 #
 
 spweights.constants <- function(listw, zero.policy=NULL, adjust.n=TRUE) {
@@ -105,7 +105,7 @@ lag.listw <- function(x, var, zero.policy=NULL, NAOK=FALSE, ...) {
 				naok=NAOK, PACKAGE="spdep")
 
 		}
-	} 
+	}
     }
     if (any(is.na(res))) warning("NAs in lagged values")
     res
@@ -154,10 +154,10 @@ listw2U <- function(listw) {
 			    iwt <- wts[[i]]
 			    vlist[[i]] <- numeric(length=length(inl))
 			    for (j in 1:length(inl)) {
-				if (inl[j] %in% inb) 
+				if (inl[j] %in% inb)
 				    a <- iwt[which(inb == inl[j])]
 				else a <- 0
-				if (i %in% nb[[inl[j]]]) 
+				if (i %in% nb[[inl[j]]])
 				    b <- wts[[inl[j]]][which(nb[[inl[j]]] == i)]
 				else b <- 0
 				vlist[[i]][j] <- 0.5 * (a + b)
@@ -209,9 +209,16 @@ listw2star <- function(listw, ireg, style, n, D, a, zero.policy=NULL) {
 spdep <- function(build=FALSE) {
 #	require("utils")
 	.DESC <- packageDescription("spdep")
-	.spdep.Version <- paste(.DESC[["Package"]], ", version ", 
+	.spdep.Version <- paste(.DESC[["Package"]], ", version ",
 		.DESC[["Version"]], ", ", .DESC[["Date"]], sep="")
 	.spdep.Build <- paste("build:", .DESC[["Built"]])
 	if (build) return(c(.spdep.Version, .spdep.Build))
 	else return(.spdep.Version)
+}
+
+
+
+# find neighbor values
+find_xj <- function(x, nb) {
+  lapply(nb, FUN = function(nbs_i) x[nbs_i])
 }

--- a/man/moran_bv.Rd
+++ b/man/moran_bv.Rd
@@ -40,7 +40,7 @@ listw <- nb2listw(boston.soi)
 moran_bv(x, y, listw)
 }
 \references{
-\href{https://geodacenter.github.io/workbook/5b_global_adv/lab5b.html}{Global Spatial Autocorrelation (2): Bivariate, Differential and EB Rate Moran Scatter Plot, Luc Anselin}
+Wartenberg, D. (1985), Multivariate Spatial Correlation: A Method for Exploratory Geographical Analysis. Geographical Analysis, 17: 263-283. \doi{10.1111/j.1538-4632.1985.tb00849.x}
 }
 
 \author{Josiah Parry \email{josiah.parry@gmail.com}}

--- a/man/moran_bv.Rd
+++ b/man/moran_bv.Rd
@@ -1,0 +1,46 @@
+\name{moran_bv}
+\alias{moran_bv}
+\title{Compute the Global Bivariate Moran's I}
+\usage{
+moran_bv(x, y, listw, nsim = 99, scale = TRUE)
+}
+\arguments{
+\item{x}{a numeric vector of same length as \code{y}.}
+
+\item{y}{a numeric vector of same length as \code{x}.}
+
+\item{listw}{a listw object for example as created by \code{nb2listw()}.}
+
+\item{nsim}{the number of simulations to run.}
+
+\item{scale}{default \code{TRUE}.}
+}
+\value{
+a named list with two elements \code{Ib} and \code{p_sim} containing the bivariate Moran's I and simulated p-value respectively.
+}
+\description{
+Given two continuous numeric variables, calculate the bivariate Moran's I. See details for more.
+}
+\details{
+The Global Bivariate Moran is defined as
+
+\eqn{
+I_B = \frac{\Sigma_i(\Sigma_j{w_{ij}y_j\times x_i})}{\Sigma_i{x_i^2}}
+}
+
+It is important to note that this is a measure of autocorrelation of X
+with the spatial lag of Y. As such, the resultant measure may overestimate the amount of
+spatial autocorrelation which may be a product of the inherent correlation of X and Y.
+}
+\examples{
+data(boston, package = "spData")
+x <- boston.c$CRIM
+y <- boston.c$NOX
+listw <- nb2listw(boston.soi)
+moran_bv(x, y, listw)
+}
+\references{
+\href{https://geodacenter.github.io/workbook/5b_global_adv/lab5b.html}{Global Spatial Autocorrelation (2): Bivariate, Differential and EB Rate Moran Scatter Plot, Luc Anselin}
+}
+
+\author{Josiah Parry \email{josiah.parry@gmail.com}}


### PR DESCRIPTION
This PR accompanies #92 for the global counterpart. 

This PR implements the global bivariate moran.

-  It adds the same `R/utils-cond-permute.R` helper functions.
- Adds another function `find_xj()` to `R/utils.R` which creates a list of neighboring values of a vector x based on a neighbor list object
- Implements the bivariate global moran using the folded pseudo p-value approach taken in pysal

```
── R CMD check results ──────────────────────────────────────── spdep 1.2-6 ────
Duration: 2m 1.4s

❯ checking package dependencies ... NOTE
  Packages suggested but not available for checking: 'spatialreg', 'RSpectra'

❯ checking installed package size ... NOTE
    installed size is  9.3Mb
    sub-directories of 1Mb or more:
      doc   6.7Mb
      etc   1.4Mb

0 errors ✔ | 0 warnings ✔ | 2 notes ✖

R CMD check succeeded
```