### PR TITLE
fix \value that referenced non-existent arguments

### DIFF
--- a/man/local_joincount_uni.Rd
+++ b/man/local_joincount_uni.Rd
@@ -21,7 +21,7 @@ local_joincount_uni(
 \item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
 }
 \value{
-a \code{data.frame} with two columns \code{join_count} and \code{p_sim} and number of rows equal to the length of arguments \code{x}, \code{nb}, and \code{wt}.
+a \code{data.frame} with two columns \code{join_count} and \code{p_sim} and number of rows equal to the length of \code{x}.
 }
 \description{
 The univariate local join count statistic is used to identify clusters of rarely occurring binary variables. The binary variable of interest should occur less


### PR DESCRIPTION
The man page for the local join count made reference to non-existent arguments `nb` and `wt`. These have been removed.