### PR TITLE
implement bivariate local join count

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,7 +80,7 @@ export(set.VerboseOption, get.VerboseOption, set.ZeroPolicyOption,
 export(set.mcOption, get.mcOption, set.coresOption, get.coresOption,
         set.ClusterOption, get.ClusterOption)
 
-export(localmoran_bv, moran_bv,local_joincount_uni)
+export(localmoran_bv, moran_bv,local_joincount_uni, local_joincount_bv)
 
 
 S3method(print, nb)

--- a/R/local-joincount-bivariate.R
+++ b/R/local-joincount-bivariate.R
@@ -46,6 +46,7 @@ local_joincount_bv <- function(x, z, listw, nsim = 199, alternative = "two.sided
     message(
       "Co-location present for non-observed events.\n  e.g. xi == 0 and zi == 0"
     )
+    stop("Neither CLC or BJC cases identified.", call. = FALSE)
   } else {
     stop("Neither CLC or BJC cases identified.", call. = FALSE)
   }

--- a/R/local-joincount-bivariate.R
+++ b/R/local-joincount-bivariate.R
@@ -1,0 +1,88 @@
+# small functions to calculate join count
+jc_clc_calc <- function(x, z, listw) lag.listw(listw, x * z) * (x * z)
+jc_bjc_calc <- function(x, z, listw) (x * (1 - z)) * lag.listw(listw, z * (1-x))
+
+
+local_joincount_bv <- function(x, z, listw, nsim = 199, alternative = "two.sided") {
+
+  # check that x & z contains only 0 and 1 or TRUE FALSE
+  if (!(is.numeric(x) || is.logical(x))) stop("`x` must be an integer or logical.")
+  if (!(is.numeric(z) || is.logical(z))) stop("`z` must be an integer or logical.")
+
+  # make sure values are 0 or 1
+  if (!all(as.integer(x) %in% c(0L, 1L))) {
+    stop("`x` must only contain 0 and 1 or TRUE and FALSE")
+  }
+
+  # make sure values are 0 or 1
+  if (!all(as.integer(z) %in% c(0L, 1L))) {
+    stop("`x` must only contain 0 and 1 or TRUE and FALSE")
+  }
+
+  # ensure that x, z, and listw elements are same length
+  len_check <- all.equal(
+    length(z),
+    length(x),
+    length(listw[["neighbours"]]),
+    length(listw[["weights"]])
+    )
+
+  if (!len_check) stop("`x`, `z`, and elements of `listw` must be the same length.")
+
+  # check for binary weights
+  if (is.null(attr(listw[["weights"]], "B"))) {
+    stop("weights must be binary.")
+  }
+
+  # determine if CLC or BJC case
+  if (any(x == 1 & z == 1)) {
+    case <- "CLC"
+  } else if (all((z + x) == 1)) {
+    # This ensure that BJC case is met
+    case <- "BJC"
+  } else if (any(x == 0 & z == 0)) {
+    # if at this point neither BJC or CLC have been met
+    # then check for presence of 0 == 0
+    message(
+      "Co-location present for non-observed events.\n  e.g. xi == 0 and zi == 0"
+    )
+  } else {
+    stop("Neither CLC or BJC cases identified.", call. = FALSE)
+  }
+
+  if (case == "BJC") {
+    obs <- jc_bjc_calc(x, z, listw)
+    index <- which(x == 1L & obs != 0)
+    reps <- replicate(nsim, jc_bjc_calc(x, z, permute_listw(listw)))
+  } else if (case == "CLC") {
+    # matches Pysal Join_Counts_Local_BV
+    obs <- jc_clc_calc(x, z, listw)
+    index <- which(obs > 0)
+    reps <- replicate(nsim, jc_clc_calc(x, z, permute_listw(listw)))
+  }
+
+
+  # greater
+  g <- (rowSums(reps <= obs) + 1) / (nsim + 1)
+  # less
+  l <- (rowSums(reps >= obs) + 1)/ (nsim + 1)
+  # two-sided
+  ts <- pmin(l, 1 - l)
+
+  p_value <- switch(
+    alternative,
+    less = l,
+    greater = g,
+    two.sided = ts
+  )
+
+  # assign correct p-values and ensure missing are correct
+  p_vals <- rep(NA_real_, length(x))
+  p_vals[index] <- p_value[index]
+
+  data.frame(
+    join_count = obs,
+    p_sim = p_vals
+  )
+
+}

--- a/man/local_joincount_bv.Rd
+++ b/man/local_joincount_bv.Rd
@@ -33,6 +33,8 @@ The bivariate join count (BJC) evaluates event occurrences in predefined regions
 
   The local bivariate join count statistic requires a binary weights list which can be generated with \code{nb2listw(nb, style = "B")}.
 
+  P-values are only reported for those regions that match the CLC or BJC criteria. Others will not have an associated p-value.
+
   P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared.
 }
 
@@ -46,3 +48,17 @@ Anselin, L., & Li, X. (2019). Operational Local Join Count Statistics for Cluste
 }
 
 \author{Josiah Parry \email{josiah.parry@gmail.com}}
+
+\examples{
+data("oldcol")
+listw <- nb2listw(COL.nb, style = "B")
+# Colocation case
+x <- COL.OLD[["CP"]]
+z <- COL.OLD[["EW"]]
+res <- local_joincount_bv(x, z, listw)
+na.omit(res)
+# no colocation case
+z <- 1 - x
+res <- local_joincount_bv(x, z, listw)
+na.omit(res)
+}

--- a/man/local_joincount_bv.Rd
+++ b/man/local_joincount_bv.Rd
@@ -1,0 +1,48 @@
+\name{local_joincount_bv}
+\alias{local_joincount_bv}
+\title{Calculate the local bivariate join count}
+\usage{
+local_joincount_bv(
+  x,
+  z,
+  listw,
+  nsim = 199,
+  alternative = "two.sided"
+)
+}
+
+\arguments{
+\item{x}{a binary variable either numeric or logical}
+\item{z}{a binary variable either numeric or logical with the same length as \code{x}}
+
+\item{listw}{a listw object containing binary weights created, for example, with \code{nb2listw(nb, style = "B")}}
+
+\item{nsim}{the number of conditional permutation simulations}
+
+\item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
+}
+
+\description{
+The bivariate join count (BJC) evaluates event occurrences in predefined regions and tests if the co-occurrence of events deviates from complete spatial randomness.
+}
+
+\details{
+  There are two cases that are evaluated in the bivariate join count. The first being in-situ colocation (CLC) where xi = 1 and zi = 1. The second is the general form of the bivariate join count (BJC) that is used when there is no in-situ colocation.
+
+  The BJC case "is useful when x and z cannot occur in the same location, such as when x and z correspond to two different values of a single categorical variable" or "when x and z can co-locate, but do not" (Anselin and Li, 2019). Whereas the CLC case is useful in evaluating simultaneous occurrences of events.
+
+  The local bivariate join count statistic requires a binary weights list which can be generated with \code{nb2listw(nb, style = "B")}.
+
+  P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared.
+}
+
+\value{
+a \code{data.frame} with two columns \code{join_count} and \code{p_sim} and number of rows equal to the length of arguments \code{x}.
+}
+
+
+\references{
+Anselin, L., & Li, X. (2019). Operational Local Join Count Statistics for Cluster Detection. Journal of geographical systems, 21(2), 189–210. \doi{10.1007/s10109-019-00299-x}
+}
+
+\author{Josiah Parry \email{josiah.parry@gmail.com}}


### PR DESCRIPTION
This pull request is a follow up to #94 to provide an interface to the bivariate local join count. The bivariate local join count covers cases of in-situ (CLC) and no in-situ colocation (BJC). 

This PR implements the function `local_joincount_bv()`. It checks inputs `x` and `z` to determine whether the CLC or BJC case is being assessed. Based on the identified case, calculates the appropriate bivariate join count measure. 

The example uses the columbus dataset for simplicity sake. If the detroit housing or chicago block classification data  for [the cited paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6546301/) is readily available, I am happy to modify.

Please see the below comparison to rgeoda implementations.

```r
devtools::load_all()
#> ℹ Loading spdep
#> Loading required package: sp
#> Loading required package: spData
#> To access larger datasets in this package, install the spDataLarge
#> package with: `install.packages('spDataLarge',
#> repos='https://nowosad.github.io/drat/', type='source')`
#> Loading required package: sf
#> Linking to GEOS 3.9.1, GDAL 3.2.3, PROJ 7.2.1; sf_use_s2() is TRUE
library(sf)
library(rgeoda)
#> Loading required package: digest
#> 
#> Attaching package: 'rgeoda'
#> The following object is masked from 'package:spdep':
#> 
#>     skater

guerry_path <- system.file("extdata", "Guerry.shp", package = "rgeoda")
g <- st_read(guerry_path)
#> Reading layer `Guerry' from data source 
#>   `/Library/Frameworks/R.framework/Versions/4.1-arm64/Resources/library/rgeoda/extdata/Guerry.shp' 
#>   using driver `ESRI Shapefile'
#> Simple feature collection with 85 features and 29 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 47680 ymin: 1703258 xmax: 1031401 ymax: 2677441
#> Projected CRS: NTF (Paris) / Lambert zone II
queen_w <- queen_weights(g)
g["InvCrm"] <-  1 - g[["TopCrm"]]


listw <- nb2listw(poly2nb(g), style = "B")

# BJC case ----------------------------------------------------------------
res <- local_joincount_bv(g$TopCrm, g$InvCrm, listw, nsim = 9999)
lisa <- local_bijoincount(queen_w, g[c("TopCrm", "InvCrm")], 
                          permutations = 9999)

# check that the JC values are the same
all.equal(res$join_count, lisa$lisa_vals)
#> [1] TRUE

ps <- data.frame(na.omit(cbind(res$p_sim, lisa$p_vals))) |> 
  setNames(c("impl", "rgeoda"))

ps
#>      impl rgeoda
#> 1  0.0918 0.1061
#> 2  0.0106 0.0106
#> 3  0.0127 0.0094
#> 4  0.0313 0.0251
#> 5  0.1405 0.1352
#> 6  0.0352 0.0354
#> 7  0.0314 0.0286
#> 8  0.2894 0.2881
#> 9  0.2122 0.2159
#> 10 0.3696 0.3692
#> 11 0.0390 0.0318
#> 12 0.3971 0.4010
#> 13 0.4934 0.4987
#> 14 0.0947 0.0935
#> 15 0.2938 0.2899
#> 16 0.0021 0.0020
#> 17 0.3848 0.3879
#> 18 0.0326 0.0298
#> 19 0.0969 0.0905
#> 20 0.0782 0.0771
#> 21 0.2938 0.2977
#> 22 0.0819 0.0808
#> 23 0.0004 0.0005
#> 24 0.0787 0.0789
#> 25 0.0017 0.0040

# mean abs difference
mean(abs(ps[,1] - ps[,2]))
#> [1] 0.003204


# CLC case ----------------------------------------------------------------
set.seed(0)
x <- rbinom(85, 1, 0.4)
set.seed(1)
z <- rbinom(85, 1, 0.7)

res <- local_joincount_bv(x, z, listw, nsim = 9999)
lisa <- local_multijoincount(queen_w, data.frame(x, z), permutations = 9999)

# check that join count stats are the same
all.equal(res$join_count, lisa$lisa_vals)
#> [1] TRUE

# compare p values 
ps <- data.frame(na.omit(cbind(res$p_sim, lisa$p_vals))) |> 
  setNames(c("impl", "rgeoda"))

ps
#>      impl rgeoda
#> 1  0.4067 0.4183
#> 2  0.2539 0.2479
#> 3  0.2938 0.2945
#> 4  0.1965 0.1994
#> 5  0.1250 0.1288
#> 6  0.0778 0.0778
#> 7  0.4636 0.4553
#> 8  0.4197 0.4174
#> 9  0.4250 0.4204
#> 10 0.4607 0.4582
#> 11 0.3163 0.3188
#> 12 0.0903 0.0868
#> 13 0.4026 0.4002
#> 14 0.2513 0.2579
#> 15 0.4069 0.4074
#> 16 0.3186 0.3123
#> 17 0.4540 0.4777
#> 18 0.3177 0.3106
#> 19 0.1220 0.1272
#> 20 0.1244 0.1223
#> 21 0.2628 0.2592
#> 22 0.4309 0.4245
#> 23 0.4355 0.4465
#> 24 0.1848 0.1869
#> 25 0.3464 0.3560
#> 26 0.1066 0.1031
#> 27 0.0796 0.0791

# mean abs difference
mean(abs(ps[,1] - ps[,2]))
#> [1] 0.005159259
```
