### PR TITLE
Factor perm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spdep
-Version: 1.2-6
-Date: 2022-09-16
+Version: 1.2-7
+Date: 2022-09-19
 Title: Spatial Dependence: Weighting Schemes, Statistics
 Encoding: UTF-8
 Authors@R: c(person("Roger", "Bivand", role = c("cre", "aut"), 

--- a/R/EBI.R
+++ b/R/EBI.R
@@ -58,21 +58,10 @@ EBImoran.mc <- function (n, x, listw, nsim, zero.policy = NULL,
             var <- var[i]
             return(EBImoran(z=var, ...))
         }
-        cores <- get.coresOption()
-        if (is.null(cores)) {
-        parallel <- "no"
-        } else {
-            parallel <- ifelse (get.mcOption(), "multicore", "snow")
-        }
-        ncpus <- ifelse(is.null(cores), 1L, cores)
-        cl <- NULL
-        if (parallel == "snow") {
-            cl <- get.ClusterOption()
-            if (is.null(cl)) {
-                parallel <- "no"
-                warning("no cluster in ClusterOption, parallel set to no")
-            }
-        }
+        p_setup <- parallel_setup(NULL)
+        parallel <- p_setup$parallel
+        ncpus <- p_setup$ncpus
+        cl <- p_setup$cl
         res <- boot(z, statistic=EBI_boot, R=nsim,
             sim="permutation", listw=listw, nn=m, S0=S0,
             zero.policy=zero.policy,

--- a/R/geary.R
+++ b/R/geary.R
@@ -122,21 +122,10 @@ geary.mc <- function(x, listw, nsim, zero.policy=NULL,
                 var <- var[i]
                 return(geary(x=var, ...)$C)
             }
-            cores <- get.coresOption()
-            if (is.null(cores)) {
-            parallel <- "no"
-            } else {
-                parallel <- ifelse (get.mcOption(), "multicore", "snow")
-            }
-            ncpus <- ifelse(is.null(cores), 1L, cores)
-            cl <- NULL
-            if (parallel == "snow") {
-                cl <- get.ClusterOption()
-                if (is.null(cl)) {
-                    parallel <- "no"
-                    warning("no cluster in ClusterOption, parallel set to no")
-                }
-            }
+            p_setup <- parallel_setup(NULL)
+            parallel <- p_setup$parallel
+            ncpus <- p_setup$ncpus
+            cl <- p_setup$cl
             res <- boot(x, statistic=geary_boot, R=nsim,
                 sim="permutation", listw=listw, n=n, n1=wc$n1, S0=wc$S0, 
                 zero.policy=zero.policy, parallel=parallel, ncpus=ncpus, cl=cl)

--- a/R/lee.mc.R
+++ b/R/lee.mc.R
@@ -58,21 +58,10 @@ lee.mc <- function(x, y, listw, nsim, zero.policy=NULL,
 #                return(moran(x=var, ...)$I)
 		return(lee(x=var[i,1], y=var[i,2], ...)$L)
             }
-            cores <- get.coresOption()
-            if (is.null(cores)) {
-            parallel <- "no"
-            } else {
-                parallel <- ifelse (get.mcOption(), "multicore", "snow")
-            }
-            ncpus <- ifelse(is.null(cores), 1L, cores)
-            cl <- NULL
-            if (parallel == "snow") {
-                cl <- get.ClusterOption()
-                if (is.null(cl)) {
-                    parallel <- "no"
-                    warning("no cluster in ClusterOption, parallel set to no")
-                }
-            }
+            p_setup <- parallel_setup(NULL)
+            parallel <- p_setup$parallel
+            ncpus <- p_setup$ncpus
+            cl <- p_setup$cl
             res <- boot(xy, statistic=lee_boot, R=nsim,
                 sim="permutation", listw=listw, n=n, S2=S2, 
                 zero.policy=zero.policy, parallel=parallel, ncpus=ncpus, cl=cl)

--- a/R/lisa_perm.R
+++ b/R/lisa_perm.R
@@ -146,6 +146,7 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     crd <- card(listw$neighbours)
     lww <- listw$weights
     Iis <- res[,1]
+
     env <- new.env()
     assign("z", z, envir=env)
     assign("crd", crd, envir=env)
@@ -154,6 +155,7 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     assign("Iis", Iis, envir=env)
     assign("s2", s2, envir=env)
     varlist <- ls(envir = env)
+
     permI_int <- function(i, env) {
         res_i <- rep(as.numeric(NA), 8) # initialize output
         crdi <- get("crd", envir=env)[i]
@@ -263,6 +265,7 @@ localG_perm <- function(x, listw, nsim=499, zero.policy=NULL, spChk=NULL, return
     assign("x_star", x_star, envir=env)
     assign("gstari", gstari, envir=env)
     varlist <- ls(envir = env)
+
     permG_int <- function(i, env) {
         res_i <- rep(as.numeric(NA), 6)
         crdi <- get("crd", envir=env)[i]
@@ -292,9 +295,9 @@ localG_perm <- function(x, listw, nsim=499, zero.policy=NULL, spChk=NULL, return
     }
 
     out <- run_perm(fun=permG_int, n=n, env=env, iseed=iseed, varlist=varlist)
+
     EG <- out[,1]
     VG <- out[,2]
-
     res <- (G - EG)
     res <- res / sqrt(VG)
     if (return_internals) {

--- a/R/lisa_perm.R
+++ b/R/lisa_perm.R
@@ -1,3 +1,81 @@
+parallel_setup <- function(iseed) {
+    cores <- get.coresOption()
+    if (is.null(cores)) {
+        parallel <- "no"
+    } else {
+        parallel <- ifelse (get.mcOption(), "multicore", "snow")
+    }
+    ncpus <- ifelse(is.null(cores), 1L, cores)
+    cl <- NULL
+    if (parallel == "snow") {
+        cl <- get.ClusterOption()
+        if (is.null(cl)) {
+            parallel <- "no"
+            warning("no cluster in ClusterOption, parallel set to no")
+        }
+    }
+    if (!is.null(iseed)) {
+        stopifnot(is.numeric(iseed))
+        stopifnot(length(iseed) == 1L)
+    }
+    list(parallel=parallel, ncpus=ncpus, cl=cl)
+}
+
+run_perm <- function(fun, n, env, iseed, varlist) {
+    p_setup <- parallel_setup(iseed)
+    parallel <- p_setup$parallel
+    ncpus <- p_setup$ncpus
+    cl <- p_setup$cl
+    if (parallel == "snow") {
+      if (requireNamespace("parallel", quietly = TRUE)) {
+        sI <- parallel::splitIndices(n, length(cl))
+        parallel::clusterExport(cl, varlist=varlist, envir=env)
+        if (!is.null(iseed)) parallel::clusterSetRNGStream(cl, iseed = iseed)
+        oo <- parallel::clusterApply(cl, x = sI, fun=lapply, function(i) {
+ 	    fun(i, env)})
+        out <- do.call("rbind", do.call("c", oo))
+      } else {
+        stop("parallel not available")
+      }
+    } else if (parallel == "multicore") {
+      if (requireNamespace("parallel", quietly = TRUE)) {
+        sI <- parallel::splitIndices(n, ncpus)
+        oldRNG <- RNGkind()
+        RNGkind("L'Ecuyer-CMRG")
+        if (!is.null(iseed)) set.seed(iseed)
+        oo <- parallel::mclapply(sI, FUN=lapply, function(i) {fun(i,
+            env)}, mc.cores=ncpus)
+        RNGkind(oldRNG[1])
+        out <- do.call("rbind", do.call("c", oo))
+      } else {
+        stop("parallel not available")
+      }
+    } else {
+        if (!is.null(iseed)) set.seed(iseed)
+        oo <- lapply(1:n, function(i) fun(i, env))
+        out <- do.call("rbind", oo)
+    }
+    out
+}
+
+probs_lut <- function(nsim, alternative) {
+    gr <- punif((1:(nsim+1))/(nsim+1), 0, 1)
+    ls <- rev(gr)
+    ts <- (ifelse(gr > ls, ls, gr))*2
+    if (alternative == "two.sided") {
+        probs <- ts
+        Prname <- "Pr(z != E(Gi))"
+    } else if (alternative == "greater") {
+        Prname <- "Pr(z > E(Gi))"
+        probs <- gr
+    } else {
+        Prname <- "Pr(z < E(Gi))"
+        probs <- ls
+    }
+    attr(probs, "Prname") <- Prname
+    probs
+}
+
 localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     na.action=na.fail, alternative = "two.sided",
     mlvar=TRUE, spChk=NULL, adjust.x=FALSE, sample_Ei=TRUE, iseed=NULL) {
@@ -28,23 +106,6 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     n <- length(listw$neighbours)
     if (n != length(x))stop("Different numbers of observations")
     res <- matrix(nrow=n, ncol=9)
-    gr <- punif((1:(nsim+1))/(nsim+1), 0, 1)
-    ls <- rev(gr)
-    ts <- (ifelse(gr > ls, ls, gr))*2
-    if (alternative == "two.sided") {
-        probs <- ts
-        Prname <- "Pr(z != E(Ii))"
-    } else if (alternative == "greater") {
-        Prname <- "Pr(z > E(Ii))"
-        probs <- gr
-    } else {
-        Prname <- "Pr(z < E(Ii))"
-        probs <- ls
-    }
-    Prname_rank <- paste0(Prname, " Sim")
-    Prname_sim <- "Pr(folded) Sim"
-    colnames(res) <- c("Ii", "E.Ii", "Var.Ii", "Z.Ii", Prname, Prname_rank, 
-        Prname_sim, "Skewness", "Kurtosis")
     if (adjust.x) {
         nc <- card(listw$neighbours) > 0L
 	xx <- mean(x[nc], na.rm=NAOK)
@@ -82,36 +143,34 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     }
     res[,1] <- (z/s2) * lz
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
-    if (!is.null(iseed)) {
-        stopifnot(is.numeric(iseed))
-        stopifnot(length(iseed) == 1L)
-    }
-
     crd <- card(listw$neighbours)
-    permI_int <- function(i, zi, z_i, crdi, wtsi, nsim, Ii) {
-        res_i <- rep(as.numeric(NA), 8)       
-        if (crdi > 0) {
+    lww <- listw$weights
+    Iis <- res[,1]
+    env <- new.env()
+    assign("z", z, envir=env)
+    assign("crd", crd, envir=env)
+    assign("lww", lww, envir=env)
+    assign("nsim", nsim, envir=env)
+    assign("Iis", Iis, envir=env)
+    assign("s2", s2, envir=env)
+    varlist <- ls(envir = env)
+    permI_int <- function(i, env) {
+        res_i <- rep(as.numeric(NA), 8) # initialize output
+        crdi <- get("crd", envir=env)[i]
+        if (crdi > 0) { # if i has neighbours
+            nsim <- get("nsim", envir=env)
+            zi <- get("z", envir=env)[i]
+            z_i <- get("z", envir=env)[-i]
             sz_i <- matrix(sample(z_i, size=crdi*nsim, replace=TRUE),
-                ncol=crdi, nrow=nsim)
-            lz_i <- sz_i %*% wtsi
-            res_p <- (zi/s2)*lz_i
+                ncol=crdi, nrow=nsim) # permute nsim*#neighbours from z[-i]
+            wtsi <- get("lww", envir=env)[[i]]
+            lz_i <- sz_i %*% wtsi # nsim by 1 = nsim by crdi %*% crdi by 1
+            # create nsim samples of Ii at i
+            s2 <- get("s2", envir=env)
+            res_p <- (zi/s2)*lz_i # nsim by 1 = scalar/scalar * nsim by 1
             res_i[1] <- mean(res_p)
             res_i[2] <- var(res_p)
+            Ii <- get("Iis", envir=env)[i]
             xrank <- rank(c(res_p, Ii))[(nsim + 1L)]
 	    res_i[5] <- xrank
             rnk0 <- as.integer(sum(res_p >= Ii))
@@ -124,46 +183,7 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
         res_i
     }
 
-    lww <- listw$weights
-    Iis <- res[,1]
-    if (parallel == "snow") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, length(cl))
-        env <- new.env()
-        assign("z", z, envir=env)
-        assign("crd", crd, envir=env)
-        assign("lww", lww, envir=env)
-        assign("nsim", nsim, envir=env)
-        assign("Iis", Iis, envir=env)
-        parallel::clusterExport(cl, varlist=c("z", "crd", "lww", "nsim",
-            "Iis"), envir=env)
-        if (!is.null(iseed)) parallel::clusterSetRNGStream(cl, iseed = iseed)
-        oo <- parallel::clusterApply(cl, x = sI, fun=lapply, function(i) {
- 	    permI_int(i, z[i], z[-i], crd[i], lww[[i]], nsim, Iis[i])})
-        out <- do.call("rbind", do.call("c", oo))
-        rm(env)
-      } else {
-        stop("parallel not available")
-      }
-    } else if (parallel == "multicore") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, ncpus)
-        oldRNG <- RNGkind()
-        RNGkind("L'Ecuyer-CMRG")
-        if (!is.null(iseed)) set.seed(iseed)
-        oo <- parallel::mclapply(sI, FUN=lapply, function(i) {permI_int(i,
-            z[i], z[-i], crd[i], lww[[i]], nsim, Iis[i])}, mc.cores=ncpus)
-        RNGkind(oldRNG[1])
-        out <- do.call("rbind", do.call("c", oo))
-      } else {
-        stop("parallel not available")
-      }
-    } else {
-        if (!is.null(iseed)) set.seed(iseed)
-        oo <- lapply(1:n, function(i) permI_int(i, z[i], z[-i], 
-            crd[i], lww[[i]], nsim, Iis[i]))
-        out <- do.call("rbind", oo)
-    }
+    out <- run_perm(fun=permI_int, n=n, env=env, iseed=iseed, varlist=varlist)
 
     if (sample_Ei) res[,2] <- out[,1]
     else  res[,2] <- EIc
@@ -174,14 +194,24 @@ localmoran_perm <- function(x, listw, nsim=499L, zero.policy=NULL,
     else if (alternative == "greater") 
         res[,5] <- pnorm(res[,4], lower.tail=FALSE)
     else res[,5] <- pnorm(res[,4])
+# look-up table
+    probs <- probs_lut(nsim=nsim, alternative=alternative)
+    Prname <- attr(probs, "Prname")
+    Prname_rank <- paste0(Prname, " Sim")
+    Prname_sim <- "Pr(folded) Sim"
     res[,6] <- probs[as.integer(out[,5])]
 # 210811 from https://github.com/pysal/esda/blob/4a63e0b5df1e754b17b5f1205b8cadcbecc5e061/esda/crand.py#L211-L213
     rnk0 <- as.integer(out[,6])
     drnk0 <- nsim - rnk0
     rnk <- ifelse(drnk0 < rnk0, drnk0, rnk0)
+# folded
     res[,7] <- (rnk + 1.0) / (nsim + 1.0)
+# skewness
     res[,8] <- out[,7]
+# kurtosis
     res[,9] <- out[,8]
+    colnames(res) <- c("Ii", "E.Ii", "Var.Ii", "Z.Ii", Prname, Prname_rank, 
+        Prname_sim, "Skewness", "Kurtosis")
     if (!is.null(na.act) && excl) {
 	res <- naresid(na.act, res)
     }
@@ -221,36 +251,38 @@ localG_perm <- function(x, listw, nsim=499, zero.policy=NULL, spChk=NULL, return
     } else {
         G <- lx/(x_star-c(x))
     }
+    crd <- card(listw$neighbours)
+    lww <- listw$weights
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
-    if (!is.null(iseed)) {
-        stopifnot(is.numeric(iseed))
-        stopifnot(length(iseed) == 1L)
-    }
-
-    permG_int <- function(i, xi, x_i, crdi, wtsi, nsim, Gi) {
+    env <- new.env()
+    assign("x", x, envir=env)
+    assign("crd", crd, envir=env)
+    assign("lww", lww, envir=env)
+    assign("nsim", nsim, envir=env)
+    assign("G", G, envir=env)
+    assign("x_star", x_star, envir=env)
+    assign("gstari", gstari, envir=env)
+    varlist <- ls(envir = env)
+    permG_int <- function(i, env) {
         res_i <- rep(as.numeric(NA), 6)
-        if (crdi > 0) {
+        crdi <- get("crd", envir=env)[i]
+        if (crdi > 0) { # if i has neighbours
+            nsim <- get("nsim", envir=env)
+            xi <- get("x", envir=env)[i]
+            x_i <- get("x", envir=env)[-i]
             sx_i <- matrix(sample(x_i, size=crdi*nsim, replace=TRUE),
-                ncol=crdi, nrow=nsim)
-            lx_i <- sx_i %*% wtsi
-            res_p <- lx_i/(x_star-xi)
+                ncol=crdi, nrow=nsim) # permute nsim*#neighbours from x[-i]
+            wtsi <- get("lww", envir=env)[[i]]
+            lx_i <- sx_i %*% wtsi # nsim by 1 = nsim by crdi %*% crdi by 1
+            # create nsim samples of Gi at i
+            x_star <- get("x_star", envir=env)
+            gstari <- get("gstari", envir=env)
+            # nsim by 1 = nsim by 1 / scalar
+            if (gstari) res_p <- lx_i/x_star
+            else res_p <- lx_i/(x_star-xi)
             res_i[1] <- mean(res_p)
             res_i[2] <- var(res_p)
+            Gi <- get("G", envir=env)[i]
 	    res_i[3] <- rank(c(res_p, Gi))[(nsim + 1L)]
             res_i[4] <- as.integer(sum(res_p >= Gi))
             res_i[5] <- e1071::skewness(res_p)
@@ -259,66 +291,15 @@ localG_perm <- function(x, listw, nsim=499, zero.policy=NULL, spChk=NULL, return
         res_i
     }
 
-    crd <- card(listw$neighbours)
-    lww <- listw$weights
-
-    if (parallel == "snow") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, length(cl))
-        env <- new.env()
-        assign("x", x, envir=env)
-        assign("crd", crd, envir=env)
-        assign("lww", lww, envir=env)
-        assign("nsim", nsim, envir=env)
-        assign("G", G, envir=env)
-        parallel::clusterExport(cl, varlist=c("x", "crd", "lww", "nsim", "G"),
-            envir=env)
-        if (!is.null(iseed)) parallel::clusterSetRNGStream(cl, iseed = iseed)
-        oo <- parallel::clusterApply(cl, x = sI, fun=lapply, function(i) {
- 	    permG_int(i, x[i], x[-i], crd[i], lww[[i]], nsim, G[i])})
-        out <- do.call("rbind", do.call("c", oo))
-        rm(env)
-      } else {
-        stop("parallel not available")
-      }
-    } else if (parallel == "multicore") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, ncpus)
-        oldRNG <- RNGkind()
-        RNGkind("L'Ecuyer-CMRG")
-        if (!is.null(iseed)) set.seed(iseed)
-        oo <- parallel::mclapply(sI, FUN=lapply, function(i) {permG_int(i,
-            x[i], x[-i], crd[i], lww[[i]], nsim, G[i])}, mc.cores=ncpus)
-        RNGkind(oldRNG[1])
-        out <- do.call("rbind", do.call("c", oo))
-      } else {
-        stop("parallel not available")
-      }
-    } else {
-        if (!is.null(iseed)) set.seed(iseed)
-        oo <- lapply(1:n, function(i) permG_int(i, x[i], x[-i], 
-            crd[i], lww[[i]], nsim, G[i]))
-        out <- do.call("rbind", oo)
-    }
+    out <- run_perm(fun=permG_int, n=n, env=env, iseed=iseed, varlist=varlist)
     EG <- out[,1]
     VG <- out[,2]
 
     res <- (G - EG)
     res <- res / sqrt(VG)
     if (return_internals) {
-        gr <- punif((1:(nsim+1))/(nsim+1), 0, 1)
-        ls <- rev(gr)
-        ts <- (ifelse(gr > ls, ls, gr))*2
-        if (alternative == "two.sided") {
-            probs <- ts
-            Prname <- "Pr(z != E(Gi))"
-        } else if (alternative == "greater") {
-            Prname <- "Pr(z > E(Gi))"
-            probs <- gr
-        } else {
-            Prname <- "Pr(z < E(Gi))"
-            probs <- ls
-        }
+        probs <- probs_lut(nsim=nsim, alternative=alternative)
+        Prname <- attr(probs, "Prname")
         Prname_rank <- paste0(Prname, " Sim")
         Prname_sim <- "Pr(folded) Sim"
         if (alternative == "two.sided") 
@@ -326,11 +307,13 @@ localG_perm <- function(x, listw, nsim=499, zero.policy=NULL, spChk=NULL, return
         else if (alternative == "greater") 
             pv <- pnorm(res, lower.tail=FALSE)
         else pv <- pnorm(res)
+# look-up table
         pu <- probs[as.integer(out[,3])]
 # 210811 from https://github.com/pysal/esda/blob/4a63e0b5df1e754b17b5f1205b8cadcbecc5e061/esda/crand.py#L211-L213
         rnk0 <- as.integer(out[,4])
         drnk0 <- nsim - rnk0
         rnk <- ifelse(drnk0 < rnk0, drnk0, rnk0)
+# folded
         pr <- (rnk + 1.0) / (nsim + 1.0)
         resint <- cbind(G=G, EG=EG, VG=VG, pv=pv, pu=pu, pr=pr,
             sk=out[,5], ku=out[,6])

--- a/R/local-moran-bv.R
+++ b/R/local-moran-bv.R
@@ -5,27 +5,95 @@ local_moran_bv_calc <- function(x, y, listw) {
 }
 
 
-localmoran_bv <- function(x, y, listw, nsim = 199, scale = TRUE) {
+localmoran_bv <- function(x, y, listw, nsim = 199, scale = TRUE,
+  alternative="two.sided", iseed=1L) {
+  stopifnot(length(x) == length(y))
+  if(!inherits(listw, "listw")) stop(paste(deparse(substitute(listw)),
+    "is not a listw object"))
+# FIXME is listw assumed to be row-standardized?
+  n <- length(listw$neighbours)
+  stopifnot(n == length(x))
+  if(!is.numeric(x)) stop(paste(deparse(substitute(x)),
+    "is not a numeric vector"))
+  if(!is.numeric(y)) stop(paste(deparse(substitute(y)),
+    "is not a numeric vector"))
+# FIXME no na handling for x or y
+  if (missing(nsim)) stop("nsim must be given")
+  stopifnot(all(!is.na(x)))
+  stopifnot(all(!is.na(y)))
 
   # the variables should be scaled and are by default
   if (scale) {
     x <- as.numeric(scale(x))
     y <- as.numeric(scale(y))
   }
+  cards <- card(listw$neighbours)
+  stopifnot(all(cards > 0L))
+# FIXME no zero.policy handling
+  if (nsim < 1) stop("nsim too small")
 
   obs <- local_moran_bv_calc(x, y, listw)
-  # create replicates as reference distribution
-  reps <- replicate(
-    nsim,
-    local_moran_bv_calc(x, y, permute_listw(listw))
-    )
 
-  # calculate folded p-value
-  p_sim <- (rowSums(obs <= reps) + 1 )/ (nsim + 1)
+  crd <- card(listw$neighbours)
+  lww <- listw$weights
+  n <- length(lww)
 
-  # return results as data.frame
-  data.frame("Ib" = obs,
-             p_sim = pmin(p_sim, 1 - p_sim)
-  )
+  env <- new.env()
+  assign("x", x, envir=env)
+  assign("y", y, envir=env)
+  assign("crd", crd, envir=env)
+  assign("lww", lww, envir=env)
+  assign("nsim", nsim, envir=env)
+  assign("obs", obs, envir=env)
+  varlist <- ls(envir = env)
+
+  permI_bv_int <- function(i, env) {
+    res_i <- rep(as.numeric(NA), 4) # initialize output
+    crdi <- get("crd", envir=env)[i]
+    if (crdi > 0) { # if i has neighbours
+      nsim <- get("nsim", envir=env)
+      xi <- get("x", envir=env)[i]
+      y_i <- get("y", envir=env)[-i]
+      sy_i <- matrix(sample(c(y_i), size=crdi*nsim, replace=TRUE),
+        ncol=crdi, nrow=nsim) # permute nsim*#neighbours from y[-i]
+      wtsi <- get("lww", envir=env)[[i]]
+      res_p <- xi * sy_i %*% wtsi
+      # res_p length nsim for obs i conditional draws
+      res_i[1] <- mean(res_p)
+      res_i[2] <- var(res_p)
+      obsi <- get("obs", envir=env)[i]
+      res_i[3] <- rank(c(res_p, obsi))[(nsim + 1L)]
+      res_i[4] <- as.integer(sum(res_p >= obsi))
+    }
+    res_i
+  }
+
+  out <- run_perm(fun=permI_bv_int, n=n, env=env, iseed=iseed, varlist=varlist)
+
+  res <- matrix(nrow=n, ncol=7)
+  res[,1] <- obs
+  res[,2] <- out[,1]
+  res[,3] <- out[,2]
+  res[,4] <- (res[,1] - res[,2])/sqrt(res[,3])
+  if (alternative == "two.sided") 
+    res[,5] <- 2 * pnorm(abs(res[,4]), lower.tail=FALSE)
+  else if (alternative == "greater") 
+    res[,5] <- pnorm(res[,4], lower.tail=FALSE)
+  else res[,5] <- pnorm(res[,4])
+# look-up table
+  probs <- probs_lut(stat="Ibv", nsim=nsim, alternative=alternative)
+  res[,6] <- probs[as.integer(out[,3])]
+  rnk0 <- as.integer(out[,4])
+  drnk0 <- nsim - rnk0
+  rnk <- ifelse(drnk0 < rnk0, drnk0, rnk0)
+# folded
+  res[,7] <- (rnk + 1.0) / (nsim + 1.0)
+  Prname <- attr(probs, "Prname")
+  Prname_rank <- paste0(Prname, " Sim")
+  Prname_sim <- "Pr(folded) Sim"
+  colnames(res) <- c("Ibvi", "E.Ibvi", "Var.Ibvi", "Z.Ibvi", Prname,
+    Prname_rank, Prname_sim)
+  class(res) <- c("localmoran", class(res))
+  res
 }
 

--- a/R/localC.R
+++ b/R/localC.R
@@ -231,6 +231,7 @@ localC_perm_calc <- function(x, listw, obs, nsim, alternative="two.sided",
     assign("obs", obs, envir=env)
     assign("nc", nc, envir=env)
     varlist <- ls(envir = env)
+
     permC_int <- function(i, env) {
 #    permC_int <- function(i, zi, z_i, crdi, wtsi, nsim, Ci, nc) {
       res_i <- rep(as.numeric(NA), 8)

--- a/R/localC.R
+++ b/R/localC.R
@@ -214,64 +214,53 @@ localC_perm_calc <- function(x, listw, obs, nsim, alternative="two.sided",
   zero.policy=NULL, iseed=NULL) {
     nc <- ncol(x)
     stopifnot(nc > 0L)
-    gr <- punif((1:(nsim+1))/(nsim+1), 0, 1)
-    ls <- rev(gr)
-    ts <- (ifelse(gr > ls, ls, gr))*2
-    if (alternative == "two.sided") {
-        probs <- ts
-        Prname <- "Pr(z != E(Ci))"
-    } else if (alternative == "greater") {
-        Prname <- "Pr(z > E(Ci))"
-        probs <- gr
-    } else {
-        Prname <- "Pr(z < E(Ci))"
-        probs <- ls
-    }
     n <- length(listw$neighbours)
-    if (n != nrow(x))stop("Different numbers of observations")
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
-    if (!is.null(iseed)) {
-        stopifnot(is.numeric(iseed))
-        stopifnot(length(iseed) == 1L)
-    }
+    if (n != nrow(x))stop("Different numbers of observations")
+    probs <- probs_lut(nsim=nsim, alternative=alternative)
+    Prname <- attr(probs, "Prname")
 
     crd <- card(listw$neighbours)
-    permC_int <- function(i, zi, z_i, crdi, wtsi, nsim, Ci, nc) {
+    z <- scale(x)
+    lww <- listw$weights
+    env <- new.env()
+    assign("z", z, envir=env)
+    assign("crd", crd, envir=env)
+    assign("lww", lww, envir=env)
+    assign("nsim", nsim, envir=env)
+    assign("obs", obs, envir=env)
+    assign("nc", nc, envir=env)
+    varlist <- ls(envir = env)
+    permC_int <- function(i, env) {
+#    permC_int <- function(i, zi, z_i, crdi, wtsi, nsim, Ci, nc) {
       res_i <- rep(as.numeric(NA), 8)
-      if (crdi > 0) {
-        if (nc == 1L) {
+      crdi <- get("crd", envir=env)[i]
+      if (crdi > 0) { # if i has neighbours
+        nsim <- get("nsim", envir=env)
+        zi <- get("z", envir=env)[i,,drop=FALSE]
+        z_i <- get("z", envir=env)[-i,]
+        wtsi <- get("lww", envir=env)[[i]]
+        nc <- get("nc", envir=env)
+        if (nc == 1L) { # if univariate
           sz_i <- matrix(sample(c(z_i), size=crdi*nsim, replace=TRUE),
-            ncol=crdi, nrow=nsim)
+            ncol=crdi, nrow=nsim) # permute nsim*#neighbours from z[-i]
           diffs <- (c(zi) - sz_i)^2
           res_p <- c(diffs %*% wtsi)
-        } else {
-          res_p <- numeric(length=nsim)
+        } else { # else multivariate
+          res_p <- numeric(length=nsim) # for cumulation across columns
           sii <- sample.int(nrow(z_i), size=crdi*nsim, replace=TRUE)
-          for (j in 1:nc) {
-            sz_i <- matrix(z_i[sii, j], ncol=crdi, nrow=nsim)
+          for (j in 1:nc) { # permute nsim*#neighbours row indices from z[-i]
+            # create nsim by crdi matrix of z[-i, j] for j-th column
+            sz_i <- matrix(z_i[sii, j], ncol=crdi, nrow=nsim) 
             diffs <- (zi[, j] - sz_i)^2
-            res_p <- res_p + c(diffs %*% wtsi)
+            res_p <- res_p + c(diffs %*% wtsi) # cumulate across columns
           }
-          res_p <- res_p/nc
+          res_p <- res_p/nc # nsim simulated local Gi
         }
-# res_p length nsim for obs i conditional draws
+        # res_p length nsim for obs i conditional draws
         res_i[1] <- mean(res_p)
         res_i[2] <- var(res_p)
+        Ci <- get("obs", envir=env)[i]
         res_i[5] <- rank(c(res_p, Ci))[(nsim + 1L)]
         res_i[6] <- as.integer(sum(res_p >= Ci))
         res_i[7] <- e1071::skewness(res_p)
@@ -279,47 +268,9 @@ localC_perm_calc <- function(x, listw, obs, nsim, alternative="two.sided",
       }
       res_i
     }
-    z <- scale(x)
-    lww <- listw$weights
-    if (parallel == "snow") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, length(cl))
-        env <- new.env()
-        assign("z", z, envir=env)
-        assign("crd", crd, envir=env)
-        assign("lww", lww, envir=env)
-        assign("nsim", nsim, envir=env)
-        assign("obs", obs, envir=env)
-        assign("nc", nc, envir=env)
-        parallel::clusterExport(cl, varlist=c("z", "crd", "lww", "nsim",
-          "obs", "nc"), envir=env)
-        if (!is.null(iseed)) parallel::clusterSetRNGStream(cl, iseed = iseed)
-        oo <- parallel::clusterApply(cl, x = sI, fun=lapply, function(i) {
-          permC_int(i, z[i,,drop=FALSE], z[-i,], crd[i], lww[[i]], nsim,
-          obs[i], nc)})
-        res <- do.call("rbind", do.call("c", oo))
-        rm(env)
-      } else {
-        stop("parallel not available")
-      }
-    } else if (parallel == "multicore") {
-      if (requireNamespace("parallel", quietly = TRUE)) {
-        sI <- parallel::splitIndices(n, ncpus)
-        oldRNG <- RNGkind()
-        RNGkind("L'Ecuyer-CMRG")
-        oo <- parallel::mclapply(sI, FUN=lapply, function(i) {permC_int(i, 
-          z[i,,drop=FALSE], z[-i,], crd[i], lww[[i]], nsim, obs[i], nc)},
-          mc.cores=ncpus)
-        RNGkind(oldRNG[1])
-        res <- do.call("rbind", do.call("c", oo))
-      } else {
-        stop("parallel not available")
-      }
-    } else {
-      oo <- lapply(1:n, function(i) permC_int(i, z[i,,drop=FALSE], z[-i,],
-        crd[i], lww[[i]], nsim, obs[i], nc))
-      res <- do.call("rbind", oo)
-    }
+
+    res <- run_perm(fun=permC_int, n=n, env=env, iseed=iseed, varlist=varlist)
+
     res[,3] <- (obs - res[,1])/sqrt(res[,2])
     if (alternative == "two.sided")
       res[,4] <- 2 * pnorm(abs(res[,3]), lower.tail=FALSE)

--- a/R/localC.R
+++ b/R/localC.R
@@ -217,7 +217,7 @@ localC_perm_calc <- function(x, listw, obs, nsim, alternative="two.sided",
     n <- length(listw$neighbours)
 
     if (n != nrow(x))stop("Different numbers of observations")
-    probs <- probs_lut(nsim=nsim, alternative=alternative)
+    probs <- probs_lut(stat="C", nsim=nsim, alternative=alternative)
     Prname <- attr(probs, "Prname")
 
     crd <- card(listw$neighbours)

--- a/R/localmoran.exact.R
+++ b/R/localmoran.exact.R
@@ -50,21 +50,10 @@ localmoran.exact <- function(model, select, nb, glist = NULL, style = "W",
 	a <- sum(sapply(B$weights, function(x) sqrt(sum(x^2))))
     } else if (style == "C") a <- sum(unlist(B$weights))
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
+    p_setup <- parallel_setup(NULL)
+    parallel <- p_setup$parallel
+    ncpus <- p_setup$ncpus
+    cl <- p_setup$cl
 
     exactLocalMoran_int <- function(i, select, B, style, n, D, a, 
         zero.policy, u, X, utu, alternative, useTP, truncErr, zeroTreat) {

--- a/R/moran-bv.R
+++ b/R/moran-bv.R
@@ -1,23 +1,43 @@
-moran_bv <- function(x, y, listw, nsim = 99, scale = TRUE) {
+moran_bv <- function(x, y, listw, nsim = 499, scale = TRUE) {
+  stopifnot(length(x) == length(y))
+  if(!inherits(listw, "listw")) stop(paste(deparse(substitute(listw)),
+    "is not a listw object"))
+# FIXME is listw assumed to be row-standardized?
+  n <- length(listw$neighbours)
+  stopifnot(n == length(x))
+  if(!is.numeric(x)) stop(paste(deparse(substitute(x)),
+    "is not a numeric vector"))
+  if(!is.numeric(y)) stop(paste(deparse(substitute(y)),
+    "is not a numeric vector"))
+# FIXME no na handling for x or y
+  if (missing(nsim)) stop("nsim must be given")
+  stopifnot(all(!is.na(x)))
+  stopifnot(all(!is.na(y)))
+
   # variables should always be centered and scaled
   if (scale) {
     x <- scale(x)
     y <- scale(y)
   }
+  cards <- card(listw$neighbours)
+  stopifnot(all(cards > 0L))
+# FIXME no zero.policy handling
+  if (nsim < 1) stop("nsim too small")
 
-  obs <- sum(lag.listw(listw, y) * x) / sum(x ^ 2)
+  bvm <- function(x, y, listw) {
+    sum(lag.listw(listw, y) * x) / sum(x ^ 2)
+  }
+  obs <- bvm(x, y, listw)
 
-  # create simulated distribution using permuted listw object
-  reps <- replicate(
-    nsim,
-    sum(lag.listw(permute_listw(listw), y) * x) / sum(x ^ 2)
-  )
-
-  # calculate p-value from replicates
-  p_sim <- (sum(obs <= reps) + 1 ) / (nsim + 1)
-
-  list("Ib" = obs,
-       # folded p-sim
-       p_sim = pmin(p_sim, 1 - p_sim)
-  )
+  xx <- data.frame(x, y)
+  bvm_boot <- function(var, i, ...) {
+    return(bvm(x=var[i,1], y=var[i,2], ...)) # as lee.mc
+  }
+  p_setup <- parallel_setup(NULL)
+  parallel <- p_setup$parallel
+  ncpus <- p_setup$ncpus
+  cl <- p_setup$cl
+  res <- boot(xx, statistic=bvm_boot, R=nsim,
+    sim="permutation", listw=listw, parallel=parallel, ncpus=ncpus, cl=cl)
+  return(res)
 }

--- a/R/moran.R
+++ b/R/moran.R
@@ -137,21 +137,10 @@ moran.mc <- function(x, listw, nsim, zero.policy=NULL,
                 var <- var[i]
                 return(moran(x=var, ...)$I)
             }
-            cores <- get.coresOption()
-            if (is.null(cores)) {
-            parallel <- "no"
-            } else {
-                parallel <- ifelse (get.mcOption(), "multicore", "snow")
-            }
-            ncpus <- ifelse(is.null(cores), 1L, cores)
-            cl <- NULL
-            if (parallel == "snow") {
-                cl <- get.ClusterOption()
-                if (is.null(cl)) {
-                    parallel <- "no"
-                    warning("no cluster in ClusterOption, parallel set to no")
-                }
-            }
+            p_setup <- parallel_setup(NULL)
+            parallel <- p_setup$parallel
+            ncpus <- p_setup$ncpus
+            cl <- p_setup$cl
             res <- boot(x, statistic=moran_boot, R=nsim,
                 sim="permutation", listw=listw, n=n, S0=S0, 
                 zero.policy=zero.policy, parallel=parallel, ncpus=ncpus, cl=cl)

--- a/R/moran.exact.alt.R
+++ b/R/moran.exact.alt.R
@@ -64,21 +64,10 @@ localmoran.exact.alt <- function(model, select, nb, glist = NULL, style = "W",
 	a <- sum(sapply(B$weights, function(x) sqrt(sum(x^2))))
     } else if (style == "C") a <- sum(unlist(B$weights))
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
+    p_setup <- parallel_setup(NULL)
+    parallel <- p_setup$parallel
+    ncpus <- p_setup$ncpus
+    cl <- p_setup$cl
 
     exactLocalMoranAlt_int <- function(i, B, select, style, n, D, a, 
         zero.policy, u, utu, M1, M2, useTP, truncErr, zeroTreat, alternative) {

--- a/R/mtlocalmoran.R
+++ b/R/mtlocalmoran.R
@@ -65,21 +65,10 @@ localmoran.sad <- function (model, select, nb, glist = NULL, style = "W",
 	a <- sum(sapply(B$weights, function(x) sqrt(sum(x^2))))
     } else if (style == "C") a <- sum(unlist(B$weights))
 
-    cores <- get.coresOption()
-    if (is.null(cores)) {
-        parallel <- "no"
-    } else {
-        parallel <- ifelse (get.mcOption(), "multicore", "snow")
-    }
-    ncpus <- ifelse(is.null(cores), 1L, cores)
-    cl <- NULL
-    if (parallel == "snow") {
-        cl <- get.ClusterOption()
-        if (is.null(cl)) {
-            parallel <- "no"
-            warning("no cluster in ClusterOption, parallel set to no")
-        }
-    }
+    p_setup <- parallel_setup(NULL)
+    parallel <- p_setup$parallel
+    ncpus <- p_setup$ncpus
+    cl <- p_setup$cl
 
     sadLocalMoran_int <- function(i, B, select, style=style, n, D, a,
         zero.policy=zero.policy, m, alternative=alternative, u, utu) {

--- a/inst/tinytest/test_lisa_perm.R
+++ b/inst/tinytest/test_lisa_perm.R
@@ -1,0 +1,48 @@
+library(spdep)
+data(boston, package="spData")
+lw <- nb2listw(boston.soi)
+x <- boston.c$NOX
+xx <- cbind(boston.c$NOX, boston.c$LSTAT, boston.c$RM)
+nsim <- 499L
+iseed=1L
+expect_silent(no <- system.time(localmoran_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+expect_silent(no <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+expect_silent(no <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+expect_silent(no <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+if (require(parallel, quietly=TRUE)) {
+ coresOpt <- get.coresOption()
+ nc <- detectCores(logical=FALSE)-1L
+ nc
+ mcOpt <- get.mcOption()
+# set nc to 1L here
+ if (nc > 1L) nc <- 1L
+ multicore <- snow <- NULL
+ if (!is.na(nc)) {
+  invisible(set.coresOption(nc))
+  if (mcOpt) {
+   expect_silent(multicore <- system.time(localmoran_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(multicore <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(multicore <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(multicore <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   invisible(set.mcOption(FALSE))
+   cl <- makeCluster(get.coresOption())
+   set.ClusterOption(cl)
+   expect_silent(snow <- system.time(localmoran_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   invisible(stopCluster(cl))
+   invisible(set.mcOption(mcOpt))
+  } else {
+   cl <- makeCluster(get.coresOption())
+   set.ClusterOption(cl)
+   expect_silent(snow <- system.time(localmoran_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   invisible(stopCluster(cl))
+  }
+  invisible(set.coresOption(coresOpt))
+ }
+}
+

--- a/inst/tinytest/test_lisa_perm.R
+++ b/inst/tinytest/test_lisa_perm.R
@@ -2,6 +2,7 @@ library(spdep)
 data(boston, package="spData")
 lw <- nb2listw(boston.soi)
 x <- boston.c$NOX
+y <- boston.c$LSTAT
 xx <- cbind(boston.c$NOX, boston.c$LSTAT, boston.c$RM)
 nsim <- 499L
 iseed=1L
@@ -9,6 +10,7 @@ expect_silent(no <- system.time(localmoran_perm(x, lw, nsim=nsim, iseed=iseed))[
 expect_silent(no <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
 expect_silent(no <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
 expect_silent(no <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+expect_silent(no <- system.time(localmoran_bv(x, y, lw, nsim=nsim, iseed=iseed))["elapsed"])
 if (require(parallel, quietly=TRUE)) {
  coresOpt <- get.coresOption()
  nc <- detectCores(logical=FALSE)-1L
@@ -24,6 +26,7 @@ if (require(parallel, quietly=TRUE)) {
    expect_silent(multicore <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(multicore <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(multicore <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(multicore <- system.time(localmoran_bv(x, y, lw, nsim=nsim, iseed=iseed))["elapsed"])
    invisible(set.mcOption(FALSE))
    cl <- makeCluster(get.coresOption())
    set.ClusterOption(cl)
@@ -31,6 +34,7 @@ if (require(parallel, quietly=TRUE)) {
    expect_silent(snow <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(snow <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(snow <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localmoran_bv(x, y, lw, nsim=nsim, iseed=iseed))["elapsed"])
    invisible(stopCluster(cl))
    invisible(set.mcOption(mcOpt))
   } else {
@@ -40,6 +44,7 @@ if (require(parallel, quietly=TRUE)) {
    expect_silent(snow <- system.time(localG_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(snow <- system.time(localC_perm(x, lw, nsim=nsim, iseed=iseed))["elapsed"])
    expect_silent(snow <- system.time(localC_perm(xx, lw, nsim=nsim, iseed=iseed))["elapsed"])
+   expect_silent(snow <- system.time(localmoran_bv(x, y, lw, nsim=nsim, iseed=iseed))["elapsed"])
    invisible(stopCluster(cl))
   }
   invisible(set.coresOption(coresOpt))

--- a/man/localmoran_bv.Rd
+++ b/man/localmoran_bv.Rd
@@ -2,7 +2,8 @@
 \alias{localmoran_bv}
 \title{Compute the Local Bivariate Moran's I Statistic}
 \usage{
-localmoran_bv(x, y, listw, nsim = 199, scale = TRUE)
+localmoran_bv(x, y, listw, nsim = 199, scale = TRUE, alternative="two.sided",
+ iseed=1L)
 }
 \arguments{
 \item{x}{a numeric vector of same length as \code{y}.}
@@ -14,6 +15,9 @@ localmoran_bv(x, y, listw, nsim = 199, scale = TRUE)
 \item{nsim}{the number of simulations to run.}
 
 \item{scale}{default \code{TRUE}.}
+
+\item{alternative}{a character string specifying the alternative hypothesis, must be one of "greater" (default), "two.sided", or "less".}
+\item{iseed}{default NULL, used to set the seed for possible parallel RNGs.}
 }
 \value{
 a \code{data.frame} containing two columns \code{Ib} and \code{p_sim} containing the local bivariate Moran's I and simulated p-values respectively.
@@ -35,7 +39,7 @@ columbus <- st_read(system.file("shapes/columbus.shp", package="spData"))
 nb <- poly2nb(columbus)
 listw <- nb2listw(nb)
 set.seed(1)
-(res <- localmoran_bv(columbus$CRIME, columbus$INC, listw, nsim = 99))
+(res <- localmoran_bv(columbus$CRIME, columbus$INC, listw, nsim = 499))
 }
 \references{
 Anselin, Luc, Ibnu Syabri, and Oleg Smirnov. 2002. “Visualizing Multivariate Spatial Correlation with Dynamically Linked Windows.” In New Tools for Spatial Data Analysis: Proceedings of the Specialist Meeting, edited by Luc Anselin and Sergio Rey. University of California, Santa Barbara: Center for Spatially Integrated Social Science (CSISS).

--- a/man/moran.mc.Rd
+++ b/man/moran.mc.Rd
@@ -15,7 +15,7 @@ moran.mc(x, listw, nsim, zero.policy=NULL, alternative="greater",
   \item{listw}{a \code{listw} object created for example by \code{nb2listw}}
   \item{nsim}{number of permutations}
   \item{zero.policy}{default NULL, use global option value; if TRUE assign zero to the lagged value of zones without neighbours, if FALSE assign NA}
-  \item{alternative}{a character string specifying the alternative hypothesis, must be one of "greater" (default), or "less".}
+  \item{alternative}{a character string specifying the alternative hypothesis, must be one of "greater" (default), "two.sided", or "less".}
   \item{na.action}{a function (default \code{na.fail}), can also be \code{na.omit} or \code{na.exclude} - in these cases the weights list will be subsetted to remove NAs in the data. It may be necessary to set zero.policy to TRUE because this subsetting may create no-neighbour observations. Note that only weights lists created without using the glist argument to \code{nb2listw} may be subsetted. \code{na.pass} is not permitted because it is meaningless in a permutation test.}
   \item{spChk}{should the data vector names be checked against the spatial objects for identity integrity, TRUE, or FALSE, default NULL to use \code{get.spChkOption()}}
   \item{return_boot}{return an object of class \code{boot} from the equivalent permutation bootstrap rather than an object of class \code{htest}}

--- a/man/moran_bv.Rd
+++ b/man/moran_bv.Rd
@@ -2,7 +2,7 @@
 \alias{moran_bv}
 \title{Compute the Global Bivariate Moran's I}
 \usage{
-moran_bv(x, y, listw, nsim = 99, scale = TRUE)
+moran_bv(x, y, listw, nsim = 499, scale = TRUE)
 }
 \arguments{
 \item{x}{a numeric vector of same length as \code{y}.}
@@ -16,7 +16,7 @@ moran_bv(x, y, listw, nsim = 99, scale = TRUE)
 \item{scale}{default \code{TRUE}.}
 }
 \value{
-a named list with two elements \code{Ib} and \code{p_sim} containing the bivariate Moran's I and simulated p-value respectively.
+An object of class \code{"boot"}, with the observed statistic in component \code{t0}.
 }
 \description{
 Given two continuous numeric variables, calculate the bivariate Moran's I. See details for more.
@@ -38,9 +38,21 @@ x <- boston.c$CRIM
 y <- boston.c$NOX
 listw <- nb2listw(boston.soi)
 set.seed(1)
-(res_xy <- moran_bv(x, y, listw))
+res_xy <- moran_bv(x, y, listw, nsim=499)
+res_xy$t0
+plot(res_xy)
 set.seed(1)
-(res_yx <- moran_bv(y, x, listw))
+lee_xy <- lee.mc(x, y, listw, nsim=499, return_boot=TRUE)
+lee_xy$t0
+plot(lee_xy)
+set.seed(1)
+res_yx <- moran_bv(y, x, listw, nsim=499)
+res_yx$t0
+plot(res_yx)
+set.seed(1)
+lee_yx <- lee.mc(y, x, listw, nsim=499, return_boot=TRUE)
+lee_yx$t0
+plot(lee_yx)
 }
 \references{
 Wartenberg, D. (1985), Multivariate Spatial Correlation: A Method for Exploratory Geographical Analysis. Geographical Analysis, 17: 263-283. \doi{10.1111/j.1538-4632.1985.tb00849.x}

--- a/man/set.mcOption.Rd
+++ b/man/set.mcOption.Rd
@@ -36,47 +36,48 @@ get.ClusterOption()
  
 \examples{
 ls(envir=spdep:::.spdepOptions)
-library(parallel)
-nc <- detectCores(logical=FALSE)-1L
-nc
+if (require(parallel, quietly=TRUE)) {
+ nc <- detectCores(logical=FALSE)-1L
+ nc
 # set nc to 1L here
-if (nc > 1L) nc <- 1L
+ if (nc > 1L) nc <- 1L
 #nc <- ifelse(nc > 2L, 2L, nc)
-coresOpt <- get.coresOption()
-coresOpt
-if (!is.na(nc)) {
- invisible(set.coresOption(nc))
- print(exists("moran.mc"))
- if(.Platform$OS.type == "windows") {
+ coresOpt <- get.coresOption()
+ coresOpt
+ if (!is.na(nc)) {
+  invisible(set.coresOption(nc))
+  print(exists("moran.mc"))
+  if(.Platform$OS.type == "windows") {
 # forking not permitted on Windows - start cluster
-  print(get.mcOption())
-  cl <- makeCluster(get.coresOption())
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  set.ClusterOption(cl)
-  clusterEvalQ(get.ClusterOption(), library(spdep))
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  clusterEvalQ(get.ClusterOption(), detach(package:spdep))
-  set.ClusterOption(NULL)
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  stopCluster(cl)
- } else {
-  mcOpt <- get.mcOption()
-  print(mcOpt)
-  print(mclapply(1:get.coresOption(), function(i) exists("moran.mc"),
-   mc.cores=get.coresOption()))
-  invisible(set.mcOption(FALSE))
-  cl <- makeCluster(nc)
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  set.ClusterOption(cl)
-  clusterEvalQ(get.ClusterOption(), library(spdep))
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  clusterEvalQ(get.ClusterOption(), detach(package:spdep))
-  set.ClusterOption(NULL)
-  print(clusterEvalQ(cl, exists("moran.mc")))
-  stopCluster(cl)
-  invisible(set.mcOption(mcOpt))
+   print(get.mcOption())
+   cl <- makeCluster(get.coresOption())
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   set.ClusterOption(cl)
+   clusterEvalQ(get.ClusterOption(), library(spdep))
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   clusterEvalQ(get.ClusterOption(), detach(package:spdep))
+   set.ClusterOption(NULL)
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   stopCluster(cl)
+  } else {
+   mcOpt <- get.mcOption()
+   print(mcOpt)
+   print(mclapply(1:get.coresOption(), function(i) exists("moran.mc"),
+    mc.cores=get.coresOption()))
+   invisible(set.mcOption(FALSE))
+   cl <- makeCluster(nc)
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   set.ClusterOption(cl)
+   clusterEvalQ(get.ClusterOption(), library(spdep))
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   clusterEvalQ(get.ClusterOption(), detach(package:spdep))
+   set.ClusterOption(NULL)
+   print(clusterEvalQ(cl, exists("moran.mc")))
+   stopCluster(cl)
+   invisible(set.mcOption(mcOpt))
+  }
+  invisible(set.coresOption(coresOpt))
  }
- invisible(set.coresOption(coresOpt))
 }
 }
 \keyword{ spatial }


### PR DESCRIPTION
@JosiahParry please review changes to `moran_bv()` and `localmoran_bv()`. The extraction of the shared conditional permutation elements seems to have gone OK, at head of `R/lisa_perm.R`. The local join count sketches are much poorer than the existing global measures - should take factors not logical/integer, and should accommodate a choice of level rather than impose 0/1 only. Please see https://doi.org/10.1016/j.jas.2020.105306 and https://github.com/rsbivand/LICD_article, based on and extending https://doi.org/10.1016/j.spasta.2017.03.003. If we would like to follow up the LICD approach, I could ask my co-authors for help, as we had intended to work up the prototypes used in the 2017 and 2021 articles for addition to **spdep**.