### PR TITLE
refactor local join count univariate

### DIFF
--- a/R/local-joincount-univariate.R
+++ b/R/local-joincount-univariate.R
@@ -7,17 +7,23 @@
 # 5. Calculate p-values from reps
 # 6. Put table together
 # p-values are only reported for those where xi = 1L and have at least 1 neighbor with one xj == 1L value
-local_joincount_uni <- function(x, listw, nsim = 199, alternative = "two.sided") {
+local_joincount_uni <- function(fx, chosen, listw,
+                                alternative = "two.sided",
+                                nsim = 199,
+                                iseed = NULL) {
 
-  # check that x contains only 0 and 1 or TRUE FALSE
-  if (!(is.numeric(x) || is.logical(x))) stop("`x` must be an integer or logical.")
+  # check that fx is a factor with 2 levels
+  stopifnot(is.factor(fx))
+  stopifnot(
+    "`fx` must have exactly two levels" = length(levels(fx)) == 2
+  )
 
-  # make sure values are 0 or 1
-  if (!all(as.integer(x) %in% c(0L, 1L))) {
-    stop("`x` must only contain 0 and 1 or TRUE and FALSE")
-  }
+  # check chosen value
+  stopifnot(is.character(chosen))
+  stopifnot("`chosen` value is not a level of `fx`" = chosen %in% levels(fx))
 
-  # Check for x input type  and proportion of 1s vs TRUES
+
+  # retrieve weights and neighbors
   nb <- listw[["neighbours"]]
   wt <- listw[["weights"]]
 
@@ -26,10 +32,14 @@ local_joincount_uni <- function(x, listw, nsim = 199, alternative = "two.sided")
     stop("weights must be binary.")
   }
 
+  # cast `fx` to integer
+  x <- as.integer(fx == chosen)
+
   # warn if == 1 more than half of the time
   prop_occurence <- (sum(x == 1) / length(x))
   if (!prop_occurence <= 1/2) {
-    warning("`x` should occur less than half the time. \nOccurs in ",
+    warning(
+      "Chosen level of `fx` should occur less than half the time. \nOccurs in ",
             round(prop_occurence * 100, 1), "% of observations.")
   }
 
@@ -42,28 +52,57 @@ local_joincount_uni <- function(x, listw, nsim = 199, alternative = "two.sided")
   xj_index <- which(unlist(lapply(xj, function(x) any(x == 1L))) == TRUE)
   index <- intersect(xj_index, x_index)
 
-  # create replicates
-  reps <- replicate(
-    nsim,
-    (x * lag.listw(permute_listw(listw), x))[index]
-  )
+  obs <- x * lag.listw(listw, x)
 
 
-  g <- (rowSums(reps <= obs[index]) + 1) / (nsim + 1)
-  l <- (rowSums(reps >= obs[index]) + 1)/ (nsim + 1)
-  p_value <- switch(
-    alternative,
-    less = l,
-    greater = g,
-    two.sided = pmin(l, 1 - l)
-  )
+  # create new environment to pass into parallel / permBB_int function
+  env <- new.env()
+  assign("crd", card(nb), envir = env) # cardinality
+  assign("lww", wt, envir = env) # weights
+  assign("nsim", nsim, envir=env) # weights
+  assign("xi", x, envir = env) # x col
+  assign("obs", obs, envir = env) # observed values
+  varlist = ls(envir = env)
 
-  p_values <- rep(NA_real_, length(x))
-  p_values[index] <- p_value
+  permBB_int <- function(i, env) {
 
-  data.frame(
-    join_count = obs,
-    p_sim = p_values
-  )
+    crdi <- get("crd", envir = env)[i] # get the ith cardinality
+    x <- get("xi", envir = env) # get xs
+    x_i <- x[-i] # remove the observed x value for cond. permutations
+    w_i <- get("lww", envir = env)[[i]] # weights for ith element
+    nsim <- get("nsim", envir = env) # no. simulations
+    obs <- get("obs", envir = env) # observed values
+    # create matrix of replicates
+    sx_i <- matrix(sample(x_i,
+                          size = crdi * nsim,
+                          replace = TRUE),
+                   ncol = crdi,
+                   nrow = nsim)
+
+    # calculate join counts for replicates
+    res_i <- x[i] * (sx_i %*% w_i)
+
+    # return p-value ranks these will calculate p-value
+    # uses look up table approach rather than counting
+    # no. observations in each tail
+    rank(c(res_i, obs[i]))[(nsim + 1)]
+
+  }
+
+  # create look up table of probabilities
+  probs <- probs_lut("BB", nsim, alternative)
+
+  # correct for the two-sided case
+  # commenting out because this should be handled in `probs_lut()`
+  # if (alternative == "two.sided") probs <- probs / 2
+
+  p_ranks <- run_perm(permBB_int, length(x), env, iseed, varlist)
+
+  p_res <- rep(NA_real_, length(x))
+  p_res[index] <- probs[index]
+
+  res <- data.frame(obs, p_res)
+  colnames(res) <- c("BB", attr(probs, "Prname"))
+  res
 }
 

--- a/R/local-joincount-univariate.R
+++ b/R/local-joincount-univariate.R
@@ -98,7 +98,7 @@ local_joincount_uni <- function(fx, chosen, listw,
   p_ranks <- run_perm(permBB_int, index, env, iseed, varlist)
 
   p_res <- rep(NA_real_, length(x))
-  p_res[index] <- probs[index]
+  p_res[index] <- probs[floor(p_ranks)]
 
   res <- data.frame(obs, p_res)
   colnames(res) <- c("BB", attr(probs, "Prname"))

--- a/R/local-joincount-univariate.R
+++ b/R/local-joincount-univariate.R
@@ -95,8 +95,7 @@ local_joincount_uni <- function(fx, chosen, listw,
   # correct for the two-sided case
   # commenting out because this should be handled in `probs_lut()`
   # if (alternative == "two.sided") probs <- probs / 2
-
-  p_ranks <- run_perm(permBB_int, length(x), env, iseed, varlist)
+  p_ranks <- run_perm(permBB_int, index, env, iseed, varlist)
 
   p_res <- rep(NA_real_, length(x))
   p_res[index] <- probs[index]
@@ -105,4 +104,6 @@ local_joincount_uni <- function(fx, chosen, listw,
   colnames(res) <- c("BB", attr(probs, "Prname"))
   res
 }
+
+
 

--- a/man/local_joincount_uni.Rd
+++ b/man/local_joincount_uni.Rd
@@ -5,23 +5,29 @@
 \title{Calculate the local univariate join count}
 \usage{
 local_joincount_uni(
-  x,
+  fx,
+  chosen,
   listw,
+  alternative = "two.sided",
   nsim = 199,
-  alternative = "two.sided"
+  iseed = NULL
 )
 }
 \arguments{
-\item{x}{a binary variable either numeric or logical}
+\item{fx}{a binary variable either numeric or logical}
+
+\item{chosen}{a scalar character containing the level of \code{fx} that should be considered the observed value (1).}
 
 \item{listw}{a listw object containing binary weights created, for example, with \code{nbwlistw(nb, style = "B")}}
 
+\item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
+
 \item{nsim}{the number of conditional permutation simulations}
 
-\item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
+\item{iseed}{default NULL, used to set the seed for possible parallel RNGs}
 }
 \value{
-a \code{data.frame} with two columns \code{join_count} and \code{p_sim} and number of rows equal to the length of \code{x}.
+a \code{data.frame} with two columns \code{BB} and \code{Pr()} and number of rows equal to the length of \code{x}.
 }
 \description{
 The univariate local join count statistic is used to identify clusters of rarely occurring binary variables. The binary variable of interest should occur less
@@ -34,10 +40,10 @@ P-values are estimated using a conditional permutation approach. This creates a 
 }
 \examples{
 data(oldcol)
-x <- ifelse(COL.OLD$CRIME < 35, 0L, 1L)
+fx <- as.factor(ifelse(COL.OLD$CRIME < 35, "low-crime", "high-crime"))
 listw <- nb2listw(COL.nb, style = "B")
 set.seed(1)
-(res <- local_joincount_uni(x, listw))
+(res <- local_joincount_uni(fx, chosen = "high-crime", listw))
 }
 
 \references{


### PR DESCRIPTION
This pull request refactors the implementation of `local_joincount_uni()` to follow the pattern that was explicated in #99 and vastly increases the speed of the initial implementation in #94. 

This PR does not implement `zero.policy` or `na.action` arguments. I personally think that the presence of an NA in `fx` should return an error. 

``` r
library(spdep)
#> Loading required package: sp
#> Loading required package: spData
#> To access larger datasets in this package, install the spDataLarge
#> package with: `install.packages('spDataLarge',
#> repos='https://nowosad.github.io/drat/', type='source')`
#> Loading required package: sf
#> Linking to GEOS 3.9.1, GDAL 3.2.3, PROJ 7.2.1; sf_use_s2() is TRUE
data("oldcol")
fx <- as.factor(ifelse(COL.OLD$CRIME < 35, "low-crime", "high-crime"))
listw <- nb2listw(COL.nb, style = "B")
set.seed(1)
res <- local_joincount_uni(fx, chosen = "high-crime", listw)
head(res)
#>   BB Pr(z != E(BBi))
#> 1  0              NA
#> 2  0              NA
#> 3  4            0.03
#> 4  0              NA
#> 5  0              NA
#> 6  0              NA
```

<sup>Created on 2022-09-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>