### PR TITLE
Correct the cluster label of localG()

### DIFF
--- a/R/localG.R
+++ b/R/localG.R
@@ -71,7 +71,7 @@ localG <- function(x, listw, zero.policy=attr(listw, "zero.policy"), spChk=NULL,
         colnames(ints) <- c(paste(c("", "E(", "V(", "Z("), Gi_str,
             c("", ")", ")", ")"), sep=""), Prname)
         attr(res, "internals") <- ints
-        attr(res, "cluster") <- cut(x, c(-Inf, mean(x), Inf),
+        attr(res, "cluster") <- cut(res, c(-Inf, 0, Inf),
             labels = c("Low", "High"))
         attr(res, "gstari") <- gstari
 	attr(res, "call") <- match.call()


### PR DESCRIPTION
The cluster label of localG() should be based on the z-score other than x.

(1)G
x<sub>i</sub> is not included in the G statistic of location i, so its cluster label has nothing to do with x<sub>i</sub>.

(2)Gstar
x<sub>i</sub> dose not have decisive impact on the Cluster label of location i.
For example, when the Gstar statistic of location i have significantly high value, but x<sub>i</sub> is slightly lower than mean(x), its cluster label should be "High" but not "Low".

(3)Rey et al.(2023) confirm that the cluster label of localG() should be based on the z-score other than x (p174-175) .
In p174, they say "When (G statistics) standardized, positive values imply clustering of high values, while negative implies grouping of low values."
The codes on p174-175 can also be referred.


Rey, S., Arribas-Bel, D., & Wolf, L.J. (2023). Geographic Data Science with Python (1st ed.). Chapman and Hall/CRC. https://doi.org/10.1201/9780429292507

p174
![p174](https://github.com/user-attachments/assets/cf05a9c5-58e6-4ad3-a875-0b345be94b23)

p175
![p175](https://github.com/user-attachments/assets/ef262439-08d0-4065-9aa4-40245b4fa7d2)
